### PR TITLE
Add download live video frame, sub-result and consider pre-determined sandbox responses and privacy consent parameter

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -55,6 +55,8 @@ paths:
     $ref: paths/live_videos.yaml#/live_video
   /live_videos/{live_video_id}/download:
     $ref: paths/live_videos.yaml#/download
+  /live_videos/{live_video_id}/frame:
+    $ref: paths/live_videos.yaml#/download_frame
   # Checks
   /checks:
     $ref: paths/checks.yaml#/checks

--- a/paths/live_videos.yaml
+++ b/paths/live_videos.yaml
@@ -62,3 +62,26 @@
                 format: binary
         default:
           $ref: ../responses/default_error.yaml
+
+  download_frame:
+    get:
+      summary: Download live video frame
+      description: Live video frames are downloaded using this endpoint.
+      operationId: download_live_video_frame
+      parameters:
+        - name: live_video_id
+          in: path
+          required: true
+          description: The live video’s unique identifier.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The live video frame's binary data.
+          content:
+            "*/*":
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: ../responses/default_error.yaml

--- a/schemas/checks/check.yaml
+++ b/schemas/checks/check.yaml
@@ -47,6 +47,9 @@
       applicant_id:
         type: string
         description: The ID of the applicant to do the check on.
+      privacy_notices_read_consent_given:
+        type: boolean
+        description: Indicates whether the pricvacy notices and terms of service have been read and, where specfic laws require, that consent has been given for Onfido.
       tags:
         type: array
         items:

--- a/schemas/checks/check.yaml
+++ b/schemas/checks/check.yaml
@@ -49,6 +49,7 @@
         description: The ID of the applicant to do the check on.
       privacy_notices_read_consent_given:
         type: boolean
+        writeOnly: true
         description: Indicates whether the privacy notices and terms of service have been read and, where specific laws require, that consent has been given for Onfido.
       tags:
         type: array

--- a/schemas/checks/check.yaml
+++ b/schemas/checks/check.yaml
@@ -49,7 +49,7 @@
         description: The ID of the applicant to do the check on.
       privacy_notices_read_consent_given:
         type: boolean
-        description: Indicates whether the pricvacy notices and terms of service have been read and, where specfic laws require, that consent has been given for Onfido.
+        description: Indicates whether the privacy notices and terms of service have been read and, where specific laws require, that consent has been given for Onfido.
       tags:
         type: array
         items:

--- a/schemas/checks/check.yaml
+++ b/schemas/checks/check.yaml
@@ -79,3 +79,12 @@
         writeOnly: true
         items:
           type: string
+      consider:
+        description: Returns a pre-determined consider sub-result in sandbox for the specific reports in the consider array.
+        type: array
+        items:
+          type: string
+        writeOnly: true
+      sub_result:
+        description: Triggers a pre-determined sub-result response for sandbox Document reports.
+        type: string


### PR DESCRIPTION
Adding:

- download live video frame endpoint
- ability to trigger pre-determined response for Document report sub-result 
- ability to trigger pre-determined consider for multiple report checks
- privacy_notices_read_consent_given parameter