### PR TITLE
Add RTW share code breakdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Onfido OpenAPI specification (beta)
 
-:warning: We are currently expanding our OpenAPI specification to include all report responses. It is in beta and we welcome any feedback. You can contact us via the issues tab or [email](mailto:openapi-feedback@onfido.com), but we don't yet officially support this specification. :warning:
+:warning: We are currently expanding our OpenAPI specification to include all report responses. It is in beta and we welcome any feedback. You can contact us via the issues tab or [email](mailto:openapi.feedback@onfido.com), but we don't yet officially support this specification. :warning:
 
 This specification supports Onfido API v3 onwards.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Onfido OpenAPI specification (beta)
 
-:warning: We are currently expanding our OpenAPI specification to include all report responses. It is in beta and we welcome any feedback. You can contact us via the issues tab, but we don't yet officially support this specification. :warning:
+:warning: We are currently expanding our OpenAPI specification to include all report responses. It is in beta and we welcome any feedback. You can contact us via the issues tab or [email](mailto:openapi-feedback@onfido.com), but we don't yet officially support this specification. :warning:
 
 This specification supports Onfido API v3 onwards.
 

--- a/schemas/reports/right_to_work_breakdown.yaml
+++ b/schemas/reports/right_to_work_breakdown.yaml
@@ -329,8 +329,41 @@ properties:
     properties:
       result:
         type: string
-
-
-            
-
-                        
+  share_code_validation:
+    type: object
+    description: Asserts whether the applicant has a valid right to work share code. Only returned when a share code is provided.
+    properties:
+      result:
+        type: string
+      breakdown:
+        type: object
+        properties:
+          document_id:
+            type: object
+            description: Contains the document ID number in the properties bag.
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+                properties:
+                  document_id:
+                    type: string
+                    description: The document ID to retrieve the GOV.UK evidence document of the applicant's right to work.
+          applicant_has_valid_share_code:
+            type: object
+            description: Asserts whether the provided share code is valid.
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          name_matched:
+            type: object
+            description: Asserts whether the applicant's given name matches the name on the share code results document.
+            properties:
+              result:
+                type: string
+              properties:
+                type: object  
+                


### PR DESCRIPTION
- Add breakdown for right to work report using a GOV.UK right to work share code 