### PR TITLE
feat: add spec for quality control document report resource and endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -76,6 +76,9 @@ paths:
     $ref: paths/reports.yaml#/resume
   /reports/{report_id}/cancel:
     $ref: paths/reports.yaml#/cancel
+  /reports/{report_id}/quality_control:
+    $ref: paths/reports.yaml#/quality_control
+
   # Workflow Runs
   /workflow_runs:
     $ref: paths/workflow_runs.yaml#/workflow_run
@@ -99,6 +102,6 @@ paths:
   # SDK Tokens
   /sdk_token:
     $ref: paths/sdk_tokens.yaml#/sdk_token
-  # Ping 
+  # Ping
   /ping:
     $ref: paths/ping.yaml#/ping

--- a/paths/reports.yaml
+++ b/paths/reports.yaml
@@ -80,9 +80,13 @@
           required: true
           schema:
             type: string
-      response:
+      responses:
         "200":
           description: Quality Control result of the object (Only for documents today)
+          content:
+            application/json:
+              schema:
+                $ref: ../schemas/reports/document_quality_control.yaml
         "404":
           description: No quality control done for this report
         "401":

--- a/paths/reports.yaml
+++ b/paths/reports.yaml
@@ -82,7 +82,7 @@
             type: string
       responses:
         "200":
-          description: Quality Control result of the object (Only for documents today)
+          description: Quality Control result of the object. Built with the original report results overridden by the quality control at each breakdown if the quality control exists (Only for documents today)
           content:
             application/json:
               schema:

--- a/paths/reports.yaml
+++ b/paths/reports.yaml
@@ -69,3 +69,21 @@
           description: No Content
         default:
           $ref: ../responses/default_error.yaml
+
+  quality_control:
+    get:
+      summary: Gets the quality control result when available
+      operationId: getQualityControl
+      parameters:
+        - name: report_id
+          in: path
+          required: true
+          schema:
+            type: string
+      response:
+        "200":
+          description: Quality Control result of the object (Only for documents today)
+        "404":
+          description: No quality control done for this report
+        "401":
+          description: A quality control is available but you don't have access to either the report or that quality control reason

--- a/paths/reports.yaml
+++ b/paths/reports.yaml
@@ -89,5 +89,5 @@
                 $ref: ../schemas/reports/document_quality_control.yaml
         "404":
           description: No quality control done for this report
-        "401":
+        "403":
           description: A quality control is available but you don't have access to either the report or that quality control reason

--- a/schemas/reports/document_quality_control.yaml
+++ b/schemas/reports/document_quality_control.yaml
@@ -10,7 +10,7 @@ allOf:
         type: string
         readOnly: true
         format: date-time
-        description: The date and time at which the report was first initiated. Read-only.
+        description: The date and time at which the quality control was first initiated. Read-only.
       href:
         type: string
         readOnly: true
@@ -18,15 +18,15 @@ allOf:
       status:
         type: string
         readOnly: true
-        description: The current state of the report in the checking process. Read-only.
+        description: The current state of the quality control in the checking process. Read-only. Only "completed" today.
       result:
         type: string
         readOnly: true
-        description: The result of the report. Read-only.
+        description: The result of the quality control report. Read-only.
       sub_result:
         type: string
         readOnly: true
-        description: The sub_result of the report. It gives a more detailed result for document reports only, and will be null otherwise. Read-only.
+        description: The sub_result of the quality control report. It gives a more detailed result for document reports only, and will be null otherwise. Read-only.
       check_id:
         type: string
         readOnly: true

--- a/schemas/reports/document_quality_control.yaml
+++ b/schemas/reports/document_quality_control.yaml
@@ -41,74 +41,10 @@ allOf:
           $ref: report_document.yaml
       breakdown:
         type: object
-        description: The details of the report. This is specific to each type of report.
+        description: The details of the quality control report. Only for Document today.
+        $ref: document_quality_control_breakdown.yaml
       properties:
         type: object
         readOnly: true
         additionalProperties: true
         description: The properties associated with the report, if any. Read-only.
-  - anyOf:
-    - properties:
-        name:
-          enum: ['facial_similarity_photo']
-        breakdown:
-          $ref: facial_similarity_photo_breakdown.yaml
-    - properties:
-        name:
-          enum: ['known_faces']
-        breakdown:
-          $ref: known_faces_breakdown.yaml
-        properties:
-          $ref: known_faces_properties.yaml
-    - properties:
-        name:
-          enum: ['photo_fully_auto']
-        breakdown:
-          $ref: photo_fully_auto_breakdown.yaml
-    - properties:
-        name:
-          enum: ['facial_similarity_video']
-        breakdown:
-          $ref: facial_similarity_video_breakdown.yaml
-    - properties:
-        name:
-          enum: ['document', 'document_with_address_information', 'document_with_driving_licence_information']
-        breakdown:
-          $ref: document_quality_control_breakdown.yaml
-        properties:
-          $ref: document_properties.yaml
-    - properties:
-        name:
-          enum: ['proof_of_address']
-        breakdown:
-          $ref: proof_of_address_breakdown.yaml
-        properties:
-          $ref: proof_of_address_properties.yaml
-    - properties:
-        name:
-          enum: ['watchlist_enhanced']
-        breakdown:
-          $ref: watchlist_enhanced_breakdown.yaml
-        properties:
-          $ref: watchlist_enhanced_properties.yaml
-    - properties:
-        name:
-          enum: ['watchlist_standard', 'watchlist_peps_only', 'watchlist_sanctions_only']
-        breakdown:
-          $ref: watchlist_standard_breakdown.yaml
-        properties:
-          $ref: watchlist_standard_properties.yaml
-    - properties:
-        name:
-          enum: ['right_to_work']
-        breakdown:
-          $ref: right_to_work_breakdown.yaml
-        properties:
-          $ref: right_to_work_properties.yaml
-    - properties:
-        name:
-          enum: ['identity_enhanced']
-        breakdown:
-          $ref: identity_enhanced_breakdown.yaml
-        properties:
-          $ref: identity_enhanced_properties.yaml

--- a/schemas/reports/document_quality_control.yaml
+++ b/schemas/reports/document_quality_control.yaml
@@ -1,0 +1,114 @@
+allOf:
+  - type: object
+    readOnly: true
+    properties:
+      id:
+        type: string
+        readOnly: true
+        description: The unique identifier for the report. Read-only.
+      created_at:
+        type: string
+        readOnly: true
+        format: date-time
+        description: The date and time at which the report was first initiated. Read-only.
+      href:
+        type: string
+        readOnly: true
+        description: The API endpoint to retrieve the report. Read-only.
+      status:
+        type: string
+        readOnly: true
+        description: The current state of the report in the checking process. Read-only.
+      result:
+        type: string
+        readOnly: true
+        description: The result of the report. Read-only.
+      sub_result:
+        type: string
+        readOnly: true
+        description: The sub_result of the report. It gives a more detailed result for document reports only, and will be null otherwise. Read-only.
+      check_id:
+        type: string
+        readOnly: true
+        description: The ID of the check to which the report belongs. Read-only.
+      name:
+        type: string
+        description: The name of the report type.
+      documents:
+        type: array
+        description: Array of objects with document ids that were used in the Onfido engine. [ONLY POPULATED FOR DOCUMENT AND FACIAL SIMILARITY REPORTS]
+        items:
+          $ref: report_document.yaml
+      breakdown:
+        type: object
+        description: The details of the report. This is specific to each type of report.
+      properties:
+        type: object
+        readOnly: true
+        additionalProperties: true
+        description: The properties associated with the report, if any. Read-only.
+  - anyOf:
+    - properties:
+        name:
+          enum: ['facial_similarity_photo']
+        breakdown:
+          $ref: facial_similarity_photo_breakdown.yaml
+    - properties:
+        name:
+          enum: ['known_faces']
+        breakdown:
+          $ref: known_faces_breakdown.yaml
+        properties:
+          $ref: known_faces_properties.yaml
+    - properties:
+        name:
+          enum: ['photo_fully_auto']
+        breakdown:
+          $ref: photo_fully_auto_breakdown.yaml
+    - properties:
+        name:
+          enum: ['facial_similarity_video']
+        breakdown:
+          $ref: facial_similarity_video_breakdown.yaml
+    - properties:
+        name:
+          enum: ['document', 'document_with_address_information', 'document_with_driving_licence_information']
+        breakdown:
+          $ref: document_quality_control_breakdown.yaml
+        properties:
+          $ref: document_properties.yaml
+    - properties:
+        name:
+          enum: ['proof_of_address']
+        breakdown:
+          $ref: proof_of_address_breakdown.yaml
+        properties:
+          $ref: proof_of_address_properties.yaml
+    - properties:
+        name:
+          enum: ['watchlist_enhanced']
+        breakdown:
+          $ref: watchlist_enhanced_breakdown.yaml
+        properties:
+          $ref: watchlist_enhanced_properties.yaml
+    - properties:
+        name:
+          enum: ['watchlist_standard', 'watchlist_peps_only', 'watchlist_sanctions_only']
+        breakdown:
+          $ref: watchlist_standard_breakdown.yaml
+        properties:
+          $ref: watchlist_standard_properties.yaml
+    - properties:
+        name:
+          enum: ['right_to_work']
+        breakdown:
+          $ref: right_to_work_breakdown.yaml
+        properties:
+          $ref: right_to_work_properties.yaml
+    - properties:
+        name:
+          enum: ['identity_enhanced']
+        breakdown:
+          $ref: identity_enhanced_breakdown.yaml
+        properties:
+          $ref: identity_enhanced_properties.yaml

--- a/schemas/reports/document_quality_control_breakdown.yaml
+++ b/schemas/reports/document_quality_control_breakdown.yaml
@@ -1,0 +1,390 @@
+type: object
+properties:
+  data_comparison:
+    type: object
+    description: Asserts whether data on the document is consistent with data provided when creating an applicant through the API.
+    properties:
+      result:
+        type: string
+      breakdown:
+        type: object
+        properties:
+          issuing_country:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          gender:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          date_of_expiry:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          last_name:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          document_type:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          document_numbers:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          first_name:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          date_of_birth:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+  data_validation:
+    type: object
+    description: Asserts whether algorithmically validatable elements are correct.
+    properties:
+      result:
+        type: string
+      breakdown:
+        type: object
+        properties:
+          gender:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          date_of_birth:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          document_numbers:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          document_expiration:
+            type: object
+            description: If this is flagged, the document has expired.
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          expiry_date:
+            type: object
+            description: If this is flagged, the expiration date has the incorrect format.
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          mrz:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          barcode:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+  image_integrity:
+    type: object
+    description: Asserts if the document is of sufficient quality to verify.
+    properties:
+      result:
+        type: string
+      breakdown:
+        type: object
+        properties:
+          image_quality:
+            type: object
+            description: Asserts whether the quality of the image was sufficient for processing.
+            properties:
+              result:
+                type: string
+              properties:
+                $ref: document_IQ_reasons.yaml
+          supported_document:
+            type: object
+            description: Asserts whether the submitted document is supported.
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          colour_picture:
+            type: object
+            description: Asserts whether the image was a colour one.
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          conclusive_document_quality:
+            type: object
+            description: Asserts if the document was of enough quality to be able to perform a fraud inspection.
+            properties:
+              result:
+                type: string
+              properties:
+                $ref: document_CDQ_reasons.yaml
+  visual_authenticity:
+    type: object
+    description: Asserts whether visual, non-textual, elements are correct given the type of document.
+    properties:
+      result:
+        type: string
+      breakdown:
+        type: object
+        properties:
+          fonts:
+            type: object
+            description: Fonts in the document don’t match the expected ones.
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          picture_face_integrity:
+            type: object
+            description: The pictures of the person identified on the document show signs of tampering or alteration.
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          template:
+            type: object
+            description: The document doesn’t match the expected template for the document type and country it is from.
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          security_features:
+            type: object
+            description: Security features expected on the document are missing or wrong.
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          original_document_present:
+            type: object
+            description: The document was not present when the photo was taken.
+            properties:
+              result:
+                type: string
+              properties:
+                $ref: document_ODP_reasons.yaml
+          digital_tampering:
+            type: object
+            description: Indication of digital tampering in the image.
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          other:
+            type: object
+            description: This sub-breakdown is returned for backward compatibility reasons. Its value will be consider when at least one of the other breakdowns is consider, and clear when all the other breakdowns are clear.
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          face_detection:
+            type: object
+            description: No face was detected on the document.
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+  data_consistency:
+    type: object
+    description: Asserts whether data represented in multiple places on the document is consistent.
+    properties:
+      result:
+        type: string
+      breakdown:
+        type: object
+        properties:
+          date_of_expiry:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          document_numbers:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          issuing_country:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          document_type:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          date_of_birth:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          gender:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          first_name:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          nationality:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          last_name:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          multiple_data_sources_present:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+  police_record:
+    type: object
+    description: Asserts whether the document had been identified as lost, stolen or otherwise compromised.
+    properties:
+      result:
+        type: string
+  compromised_document:
+    type: object
+    description: Asserts whether the image of the document has been found in our internal database or if it was used in a suspicious way.
+    properties:
+      result:
+        type: string
+      breakdown:
+        type: object
+        properties:
+          document_database:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          repeat_attempts:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+  age_validation:
+    type: object
+    description: Asserts whether the age calculated from the document’s date of birth data point is greater than or equal to the minimum accepted age.
+    properties:
+      result:
+        type: string
+      breakdown:
+        type: object
+        properties:
+          minimum_accepted_age:
+            type: object
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+  issuing_authority:
+    type: object
+    description: Asserts whether data on the document matches the issuing authority data.
+    properties:
+      result:
+        type: string
+      breakdown:
+        type: object
+        properties:
+          nfc_active_authentication:
+            type: object
+            description: Asserts whether the document NFC chip is original or cloned.
+            properties:
+              result:
+                type: string
+              properties:
+                type: object
+          nfc_passive_authentication:
+            type: object
+            description: Asserts whether the document NFC chip data was tampered.
+            properties:
+              result:
+                type: string
+              properties:
+                type: object


### PR DESCRIPTION
We plan on making this change on 3.0 and above as alpha clients for this feature are all on 3.0+

# How to best review

To clearly see what is different from the existing report and document report objects, look at commits [3](https://github.com/onfido/onfido-openapi-spec/commit/f55e94a51607dfe707f8e5384b85928b23e19c91) and [4](https://github.com/onfido/onfido-openapi-spec/commit/992b6f333d9450bc417a8f7c6b238ca8e99f24ff)

# Webhook

As a reminder, the availability of a quality control result for a report will be signified by a webhook of the following format:

```
{
 "payload": {
    "resource_type": "quality_control",
    "action": "quality_control.completed",
    "object": {
      "id": "<REPORT_ID>",
      "status": "completed",
      "completed_at_iso8601": "2019-10-28T15:00:39Z",
      "href": "https://api.onfido.com/v3.5/reports/<REPORT_ID>/quality_control"
    }
  }
}
```

The resource is available by doing a GET to the `href` URL, like other Onfido webhook which are thin by design.

# Design choice

## Path

The quality control is accessed from a `report id` through `/reports/{report_id}/quality_control`.  This allows easy access of the quality control from a report, instead of accessing from a new `quality_control` id.

We could have also linked the quality control to a check. However, a check can have multiple reports which are quality controlled independently, thus calling `/checks/{check_id}/quality_control` is more ambiguous. 

## Construction of the report

The quality control report is made of the original report results, overridden by the quality control if the quality control has been ran.

We made this design choice to avoid cases where all the quality controlled fields are shown as "clear" even though some non-assessed fields may not be.

**Feedbacks appreciated**