### PR TITLE
Update checks.yaml to fix lack of content type in specification

### DIFF
--- a/paths/checks.yaml
+++ b/paths/checks.yaml
@@ -86,6 +86,11 @@
       responses:
         "200":
           description: The PDF binary data
+          content:
+            "*/*":
+              schema:
+                type: string
+                format: binary
         default:
           $ref: ../responses/default_error.yaml
           


### PR DESCRIPTION
The specification for Download Check is not specifying response type and that is binary.