### PR TITLE
Adding `passenger_vehicle` property to the driver_verification report

### DIFF
--- a/schemas/reports/document_with_driver_verification_report.yaml
+++ b/schemas/reports/document_with_driver_verification_report.yaml
@@ -41,3 +41,19 @@ allOf:
                       type: string
                       format: date
                       description: Category expiry date
+              passenger_vehicle:
+                type: object
+                description: Normalised data for passenger cars
+                properties:
+                  is_qualified:
+                    description: Whether they are qualified for a passenger car, such as a “B” class in the UK 
+                    type: boolean
+                  obtainment_date:
+                    description: Date the class qualification was obtained
+                    type: string
+                    format: date
+                  expiry_date:
+                    description: Date the class qualification expires, which may be different to doc expiry
+                    type: string
+                    format: date
+


### PR DESCRIPTION
A new `passenger_vehicle` property for the driver_verification Document report variant