### PR TITLE
Update document_properties.yaml

### DIFF
--- a/schemas/reports/document_properties.yaml
+++ b/schemas/reports/document_properties.yaml
@@ -53,7 +53,7 @@ properties:
   issuing_authority:
     type: string
   real_id_compliance:
-    type: string
+    type: boolean
   address_lines:
     type: object
     properties:


### PR DESCRIPTION
Fix `real_id_compliance` property type. The actual type returned from Onfido is boolean, here is the excerpt of the test response data from sandbox:
```json
    "document_type": "driving_licence",
    "first_name": "SAMPLE",
    "gender": "Male",
    "issuing_country": "USA",
    "issuing_date": "2003-08-06",
    "issuing_state": "CA",
    "last_name": "SAMRKE BOURGEOIS",
    "nationality": null,
    "real_id_compliance": true
```
**Why this is important**: many users (including me) use OpenAPI code generator and this issue breaks the generated code. 