### PR TITLE
Fix condition to trigger GitAction workflow (2)

### DIFF
--- a/.github/workflows/generate-single-openapi-spec.yaml
+++ b/.github/workflows/generate-single-openapi-spec.yaml
@@ -39,9 +39,11 @@ jobs:
     name: Commit and push single-file OpenAPI specifications
     runs-on: ubuntu-latest
     needs: build-single-spec
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
       - uses: actions/download-artifact@v4
         with:
           name: artifacts-${{ github.workflow }}-${{ github.run_id }}-${{ github.run_number }}


### PR DESCRIPTION
We can avoid checking not being in a forked repository, since workflow in forked repository are disabled by default:
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflows-in-forked-repositories-1

Moreover anticipating this fix to be sure targeting good branch:
https://github.com/actions/checkout/issues/317#issuecomment-1221335371