### PR TITLE
Improve workflow to generate single-file OpenAPI spec

### DIFF
--- a/.github/workflows/single-file-openapi-spec.yaml
+++ b/.github/workflows/single-file-openapi-spec.yaml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_ACTION_ACCESS_TOKEN }}
+          token: ${{ secrets.GH_ACTION_ACCESS_TOKEN }}
           ref: ${{ github.ref_name }}
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/single-file-openapi-spec.yaml
+++ b/.github/workflows/single-file-openapi-spec.yaml
@@ -1,15 +1,17 @@
-name: generate-single-openapi-spec
-run-name: Build and publish single-file OpenAPI specs
+name: single-file-openapi-spec
+run-name: Generate and publish single-file OpenAPI specs
 on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'generated/artifacts/**'
   pull_request:
     branches:
       - master
 jobs:
   build-single-spec:
-    name: Build single-file OpenAPI specifications
+    name: Generate single-file OpenAPI specifications
     runs-on: ubuntu-latest
     container:
       image: openapitools/openapi-generator-cli:v7.3.0
@@ -43,6 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          token: ${{ secrets.GITHUB_ACTION_ACCESS_TOKEN }}
           ref: ${{ github.ref_name }}
       - uses: actions/download-artifact@v4
         with:
@@ -55,6 +58,7 @@ jobs:
           then
             echo "no change detected"
           else
+            echo "changes detected"
             git config user.name "GitHub Actions Bot"
             git config user.email "<>"
             git status generated/artifacts


### PR DESCRIPTION
- Add access token retrieval to grant Github action the right of pushing to master branch (same repository)
- Don't trigger workflow in case of changes to `generated/artifacts` (to allow being triggered in loop)
- A few minor changes