### PR TITLE
Ignore preCommit script result (and remove some debug prints)

### DIFF
--- a/.github/workflows/update-specs-and-client-libraries.yaml
+++ b/.github/workflows/update-specs-and-client-libraries.yaml
@@ -66,7 +66,6 @@ jobs:
         id: generator
         run: |
           ./shell/generate.sh
-          grep Onfido generated/artifacts/typescript-axios/LICENSE
       - name: Store generated artifacts and finalization scripts
         uses: actions/upload-artifact@v4
         with:
@@ -131,18 +130,18 @@ jobs:
           name: artifacts-${{ github.workflow }}-${{ github.run_id }}-${{ github.run_number }}
       - name: Integrate generated code (${{ matrix.version }})
         if: ${{ matrix.update }}
-        id: generator
         run: |
-          grep Onfido generated/artifacts/${{ matrix.generator }}/LICENSE
-
           rsync -r --delete-after --exclude='/.git*' --exclude='CHANGELOG*' \
                 --exclude-from=generators/${{ matrix.generator }}/exclusions.txt \
                 generated/artifacts/${{ matrix.generator }}/ .
-
+      - name: Run pre-commit script
+        continue-on-error: true
+        if: ${{ matrix.update }}
+        run: |
           ${{ matrix.preCommit }}
-
-          grep Onfido LICENSE
-
+      - name: Update CHANGELOG (if any change detected)
+        if: ${{ matrix.update }}
+        run: |
           if [ "$(git status --porcelain=v1 | wc -l | sed -e 's/^[[:space:]]*//')" != "" ];
           then
             if [ -f CHANGELOG ];


### PR DESCRIPTION
Rationale behind this is that we cannot do anything to fix the change when pre-commit. Instead we should fix that:
- by creating a new PR to onfido-openapi-spec, if fix is needed in the github actions command
- by amending auto-generated PR to onfido-* client lib, if fix is needed in the library