### PR TITLE
[CAT-1146] Generate OpenAPI spec with tags to publish Postman collection

### DIFF
--- a/.github/workflows/update-specs-and-client-libraries.yaml
+++ b/.github/workflows/update-specs-and-client-libraries.yaml
@@ -99,17 +99,24 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: artifacts-${{ github.workflow }}-${{ github.run_id }}-${{ github.run_number }}
+      - name: Refresh single-file OpenAPI specifications for Postman
+        run: |
+          ./shell/postman-openapi-refresh.py \
+            generated/artifacts/openapi/openapi.json \
+            generated/artifacts/openapi-postman/openapi.json
+          npm install prettier && npx prettier --write \
+            generated/artifacts/openapi-postman/openapi.json
       - name: Commit and push single-file OpenAPI specifications
         run: |
-          if [ -z "$(git status --porcelain=v1 generated/artifacts/openapi-*)" ];
+          if [ -z "$(git status --porcelain=v1 generated/artifacts/openapi*)" ];
           then
             echo "no change detected"
           else
             echo "changes detected"
             git config user.name "GitHub Actions Bot"
             git config user.email "<>"
-            git status generated/artifacts/openapi-*
-            git commit -m "Single file specifications refresh" generated/artifacts/openapi-*
+            git add generated/artifacts/openapi* && git status
+            git commit -m "Single file specifications refresh" generated/artifacts/openapi*
             git push
           fi
   update_client_libraries:
@@ -122,7 +129,7 @@ jobs:
           - generator: java/okhttp-gson
             git_repo_id: onfido-java
             preCommit: |
-              mvn -B package --file pom.xml clean
+              mvn -B package --file pom.xml clean -Dmaven.test.skip
             version: ${{ needs.generate_specs_and_libraries.outputs.java_version }}
             update: ${{ inputs.update-onfido-java }}
           - generator: typescript-axios

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-generated/**
-!generated/artifacts/
-!generated/artifacts/openapi/
+generated/*/*
+!generated/artifacts/openapi*

--- a/shell/postman-openapi-refresh.py
+++ b/shell/postman-openapi-refresh.py
@@ -5,12 +5,16 @@ import sys
 
 from dataclasses import dataclass
 
+
 @dataclass
 class Section:
     name: str
     resources: dict
 
 
+# Division of the resources by Section
+# When resource value is set to None, tag will be automatically generated
+# from path prefix replacing _ with spaces and capitalising each word
 SECTIONS = (
     Section('Core',
             {'applicants': None,
@@ -37,11 +41,11 @@ SECTIONS = (
 )
 
 
-def to_camel_case_with_spaces(snake_str: str):
+def convert_path(snake_str: str) -> None:
     return " ".join(x.capitalize() for x in snake_str.lower().split("_"))
 
 
-def convert(input_spec_file: str, output_spec_file: str):
+def convert_spec(input_spec_file: str, output_spec_file: str) -> None:
     with open(input_spec_file) as input_handler:
         input_dict = json.load(input_handler)
 
@@ -51,7 +55,7 @@ def convert(input_spec_file: str, output_spec_file: str):
             for section in SECTIONS:
                 if path_prefix in section.resources:
                     if not (resource_name := section.resources[path_prefix]):
-                        resource_name = to_camel_case_with_spaces(path_prefix)
+                        resource_name = convert_path(path_prefix)
 
                     tag = '{} | {}'.format(section.name, resource_name)
                     break
@@ -66,9 +70,10 @@ def convert(input_spec_file: str, output_spec_file: str):
     with open(output_spec_file, 'w') as fp:
         json.dump(input_dict, fp, indent=2)
 
+
 if __name__ == "__main__":
     if len(sys.argv) != 3:
         print(f"Usage: {sys.argv[0]} input-spec.json output-spec.json")
         sys.exit(1)
 
-    convert(sys.argv[1], sys.argv[2])
+    convert_spec(sys.argv[1], sys.argv[2])

--- a/shell/postman-openapi-refresh.py
+++ b/shell/postman-openapi-refresh.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+import json
+import logging
+import sys
+
+from dataclasses import dataclass
+
+@dataclass
+class Section:
+    name: str
+    resources: dict
+
+
+SECTIONS = (
+    Section('Core',
+            {'applicants': None,
+             'documents': None,
+             'live_photos': 'Live photos',
+             'live_videos': 'Live videos',
+             'workflow_runs': None,
+             'tasks': None,
+             'motion_captures': 'Motion captures',
+             'watchlist_monitors': 'Monitors',
+             'id_photos': 'ID Photos'
+             }),
+    Section('Others',
+            {'ping': None,
+             'webhooks': None,
+             'addresses': 'Address Picker',
+             'sdk_token': 'Generate SDK Token',
+             'repeat_attempts': 'Repeat attempts',
+             'extractions': 'Autofill',
+             'results_feedback': 'Fraud reporting (ALPHA)',
+             'checks': None,
+             'reports': None
+             })
+)
+
+
+def to_camel_case_with_spaces(snake_str: str):
+    return " ".join(x.capitalize() for x in snake_str.lower().split("_"))
+
+
+def convert(input_spec_file: str, output_spec_file: str):
+    with open(input_spec_file) as input_handler:
+        input_dict = json.load(input_handler)
+
+        for path in input_dict['paths'].keys():
+            path_prefix, resource_name = path.split('/')[1], None
+
+            for section in SECTIONS:
+                if path_prefix in section.resources:
+                    if not (resource_name := section.resources[path_prefix]):
+                        resource_name = to_camel_case_with_spaces(path_prefix)
+
+                    tag = '{} | {}'.format(section.name, resource_name)
+                    break
+
+            if not resource_name:
+                logging.warning('Skipping path prefix: {}'.format(path_prefix))
+                continue
+
+            for method in input_dict['paths'][path]:
+                input_dict['paths'][path][method]['tags'] = [tag]
+
+    with open(output_spec_file, 'w') as fp:
+        json.dump(input_dict, fp, indent=2)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} input-spec.json output-spec.json")
+        sys.exit(1)
+
+    convert(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
With this change we're going to automatically adding to each endpoint's method a proper tag to allow categorisation in Postman:
```sh
grep 'tags": \[' generated/artifacts/openapi-postman/openapi.json | uniq 
        "tags": ["Core | Applicants"]
        "tags": ["Core | Documents"]
        "tags": ["Core | Live photos"]
        "tags": ["Core | Live videos"]
        "tags": ["Core | Workflow Runs"]
        "tags": ["Core | Motion captures"]
        "tags": ["Core | Monitors"]
        "tags": ["Core | ID Photos"]
        "tags": ["Others | Ping"]
        "tags": ["Others | Webhooks"]
        "tags": ["Others | Address Picker"]
        "tags": ["Others | Generate SDK Token"]
        "tags": ["Others | Repeat attempts"]
        "tags": ["Others | Autofill"]
        "tags": ["Others | Fraud reporting (ALPHA)"]
        "tags": ["Others | Checks"]
        "tags": ["Others | Reports"]
```

This script will be automatically executed at PR merge. Tags are following the categories in [public documentation](https://documentation.onfido.com/), and will be shown in Postman as below:
![image](https://github.com/onfido/onfido-openapi-spec/assets/134616519/3b0c08a1-9779-4b6d-ac1b-07c18cb97bb9)
