### PR TITLE
Add dotenv dependency in package.mustache for typescript-axios

### DIFF
--- a/generators/typescript-axios/templates/package.mustache
+++ b/generators/typescript-axios/templates/package.mustache
@@ -50,6 +50,7 @@
     "jest": "^26.6.3",
     "prettier": "^1.18.2",
     "ts-jest": "^26.4.4",
+    "dotenv": "^16.4.5",
     {{! Added dependencies for tests development - END }}
     "@types/node": "^12.11.5",
     "typescript": "^4.0"


### PR DESCRIPTION
This change comes after [PR#109](https://github.com/onfido/onfido-node/pull/109)