### PR TITLE
[CAT-1120] Some improvements to CI, Postman collection generation and typescript/axios templates

### DIFF
--- a/.github/workflows/update-specs-and-client-libraries.yaml
+++ b/.github/workflows/update-specs-and-client-libraries.yaml
@@ -164,6 +164,7 @@ jobs:
           - generator: typescript-axios
             git_repo_id: onfido-node
             preCommit: |
+              npx prettier --write package.json
               npm install
             version: ${{ needs.generate_specs_and_libraries.outputs.typescript_axios_version }}
             update: ${{ inputs.update-onfido-node }}
@@ -187,6 +188,7 @@ jobs:
             version: ${{ needs.generate_specs_and_libraries.outputs.ruby_version }}
             update: ${{ inputs.update-onfido-ruby}}
     if: github.event_name == 'workflow_dispatch'
+    environment: generation
     steps:
       - uses: actions/checkout@v4
         if: ${{ matrix.update }}
@@ -208,7 +210,7 @@ jobs:
         if: ${{ matrix.update }}
         run: |
           ${{ matrix.preCommit }}
-      - name: Update CHANGELOG (if any change detected)
+      - name: Update CHANGELOG and lint .md files as needed
         if: ${{ matrix.update }}
         run: |
           if [ "$(git status --porcelain=v1 | wc -l | sed -e 's/^[[:space:]]*//')" != "" ];
@@ -218,14 +220,18 @@ jobs:
               git mv CHANGELOG CHANGELOG.md
             fi
 
-            if [ -f CHANGELOG.md ];
+            if [ -f CHANGELOG.md ] && [ -z "$(grep '${{ matrix.version }} ' CHANGELOG.md)" ];
             then
               TMP_FILE=$(mktemp)
-              ( echo "# Changelog"; echo;
-                echo "## v${{ matrix.version }} `date +'%dth %B %Y' | sed -E 's/^([2,3]?)1th/\11st/;s/^([2]?)2th/\12nd/;s/^([2]?)3th/\13rd/'`";
+              RELEASE_DATE=`date +'%dth %B %Y' | sed -E 's/^0//;s/^([2,3]?)1th/\11st/;s/^([2]?)2th/\12nd/;s/^([2]?)3th/\13rd/'`
+              COMMIT_SHA=${{ needs.generate_specs_and_libraries.outputs.last_commit_short_sha }}
+              COMMIT_URL=https://github.com/${{ github.repository_owner }}/onfido-openapi-spec/commit/${{ needs.generate_specs_and_libraries.outputs.last_commit_long_sha }}
+              ( echo -e "# Changelog\n\n## v${{ matrix.version }} $RELEASE_DATE\n\n- Refresh library up to commit: [$COMMIT_SHA]($COMMIT_URL)"
                 grep -v "^# Changelog" CHANGELOG.md ) >| $TMP_FILE
-                mv $TMP_FILE CHANGELOG.md
+              mv $TMP_FILE CHANGELOG.md
             fi
+
+            npx prettier --write *.md
           fi
       - name: Create Pull Request with changes after library update
         uses: peter-evans/create-pull-request@v6
@@ -235,7 +241,7 @@ jobs:
           commit-message: Upgrade after onfido-openapi-spec change ${{ needs.generate_specs_and_libraries.outputs.last_commit_short_sha }}
           title: Refresh ${{ matrix.git_repo_id }} after onfido-openapi-spec update (${{ needs.generate_specs_and_libraries.outputs.last_commit_short_sha }})
           body: |
-            Auto-generated PR with changes till commit ${{ github.repository_owner	}}/onfido-openapi-spec@${{ needs.generate_specs_and_libraries.outputs.last_commit_long_sha }} (included)
+            Auto-generated PR with changes till commit ${{ github.repository_owner }}/onfido-openapi-spec@${{ needs.generate_specs_and_libraries.outputs.last_commit_long_sha }} (included)
 
             Additional changes:
               - None

--- a/generators/typescript-axios/config.yaml
+++ b/generators/typescript-axios/config.yaml
@@ -1,6 +1,5 @@
 gitRepoId: onfido-node
 npmName: "@onfido/api"
-npmRepository: github:onfido/onfido-node
 npmVersion: ${CLIENT_LIBRARY_VERSION}
 enumUnknownDefaultCase: true
 supportsES6: true

--- a/generators/typescript-axios/templates/package.mustache
+++ b/generators/typescript-axios/templates/package.mustache
@@ -1,7 +1,7 @@
 {
   "name": "{{npmName}}",
   "version": "{{npmVersion}}",
-  "description": "OpenAPI client for {{npmName}}",
+  "description": "Node.js library for the Onfido API",    {{! Updated description }}
   "author": "OpenAPI-Generator Contributors",
   "repository": {
     "type": "git",
@@ -12,7 +12,13 @@
     "typescript",
     "openapi-client",
     "openapi-generator",
-    "{{npmName}}"
+    "{{npmName}}",
+    {{! Added keywords - BEGIN }}
+    "{{gitUserId}}",
+    "identity",
+    "verification",
+    "api"
+    {{! Added keywords - NED }}
   ],
   "license": "MIT",         {{! Updated license }}
   "main": "./dist/index.js",
@@ -26,6 +32,10 @@
     "build": "tsc{{#supportsES6}} && tsc -p tsconfig.esm.json{{/supportsES6}}",
     "prepare": "npm run build"
   },
+  {{! Added block for package delivery }}
+  "files": [
+    "/dist"
+  ],
   {{! Added block for integration tests }}
   "jest": {
     "preset": "ts-jest",
@@ -54,10 +64,9 @@
     {{! Added dependencies for tests development - END }}
     "@types/node": "^12.11.5",
     "typescript": "^4.0"
-  }{{#npmRepository}},{{/npmRepository}}
-{{#npmRepository}}
+  },
+  {{! Added block for package delivery }}
   "publishConfig": {
-    "registry": "{{npmRepository}}"
+    "access": "public"
   }
-{{/npmRepository}}
 }

--- a/shell/patch-openapi-definition.py
+++ b/shell/patch-openapi-definition.py
@@ -43,6 +43,10 @@ SECTIONS = (
              })
 )
 
+# Path[3] which should be promoted to section
+# e.g. /workflow_runs/:workflow_run_id/tasks -> Tasks
+PROMOTED_PATH = ('tasks', )
+
 
 def convert_path(snake_str: str) -> None:
     return " ".join(x.capitalize() for x in snake_str.lower().split("_"))
@@ -53,7 +57,12 @@ def patch_spec(input_spec_file: str, output_spec_file: str) -> dict:
         spec_dict = json.load(input_handler)
 
         for path in spec_dict['paths'].keys():
-            path_prefix, resource_name = path.split('/')[1], None
+            splitted_path, resource_name = path.split('/'), None
+
+            if len(splitted_path) > 3 and splitted_path[3] in PROMOTED_PATH:
+                path_prefix = splitted_path[3]
+            else:
+                path_prefix = splitted_path[1]
 
             for section in SECTIONS:
                 if path_prefix in section.resources:


### PR DESCRIPTION
Small improvements to CHANGELOG file entry generation ([example](https://github.com/onfido/onfido-openapi-spec/actions/runs/8972513621/job/24640687737)):

```diff
diff --git a/CHANGELOG.md b/CHANGELOG.md
index db9e953..3a854bb 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.0 6th May 2024
+
+- Refresh library up to commit: [cb6cc84](https://github.com/onfido/onfido-openapi-spec/commit/cb6cc84c6a52185d7cbf1f7672afe5803915272f)
+
 ## v3.0.0 6th May 2024
```

Include a few updates to typescript/axios package.json template after:
- https://github.com/onfido/onfido-node/pull/116
- https://github.com/onfido/onfido-node/pull/119

It calls `npx prettier` to improve formats of some generated files (package.json for typescript/axios and README.md files) and to Postman collection generation to create the _Tasks_ folder.