### PR TITLE
PHP attributes are missing in some model methods

### DIFF
--- a/generators/php/templates/model_generic.mustache
+++ b/generators/php/templates/model_generic.mustache
@@ -475,6 +475,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
@@ -501,6 +502,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
@@ -517,6 +519,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);


### PR DESCRIPTION
In PHP, some of the models methods part of `ArrayAccess` interface have a non compatible signature, adding
```#[\ReturnTypeWillChange]``` attribute fix some deprecation messages like:
```
Deprecated: Return type of Onfido\Model\CheckResponse::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /***/vendor/onfido/api-php-client/lib/Model/CheckResponse.php on line 658
```