### PR TITLE
[CAT-1120] Fix watchlist_monitors schemas

### DIFF
--- a/.github/workflows/update-specs-and-client-libraries.yaml
+++ b/.github/workflows/update-specs-and-client-libraries.yaml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_ACTION_ACCESS_TOKEN }}
+          token: ${{ secrets.GH_ACTION_ACCESS_TOKEN_NEW }}
           ref: ${{ github.ref_name }}
       - uses: actions/download-artifact@v4
         with:
@@ -234,7 +234,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         if: ${{ matrix.update }}
         with:
-          token: ${{ secrets.GH_ACTION_ACCESS_TOKEN }}
+          token: ${{ secrets.GH_ACTION_ACCESS_TOKEN_NEW }}
           commit-message: Upgrade after onfido-openapi-spec change ${{ needs.generate_specs_and_libraries.outputs.last_commit_short_sha }}
           title: Refresh ${{ matrix.git_repo_id }} after onfido-openapi-spec update (${{ needs.generate_specs_and_libraries.outputs.last_commit_short_sha }})
           body: |

--- a/paths/watchlist_monitors.yaml
+++ b/paths/watchlist_monitors.yaml
@@ -118,19 +118,24 @@ matches:
         content:
           application/json:
             schema:
-              type: array
-              title: Watchlist monitor matches
-              items:
-                type: object
-                title: Watchlist monitor match
-                properties:
-                  id:
-                    type: string
-                    format: uuid
-                    description: Monitor ID
-                  status:
-                    type: boolean
-                    description: Monitor status
+              type: object
+              title: Watchlist monitor matches list
+              required:
+                - matches
+              properties:
+                matches:
+                  type: array
+                  items:
+                    type: object
+                    title: Watchlist monitor match
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                        description: Monitor ID
+                      enabled:
+                        type: boolean
+                        description: Monitor status
 
   patch:
     summary: Set match status (BETA)
@@ -155,11 +160,13 @@ matches:
                 type: array
                 items:
                   type: string
+                  format: uuid
                   description: Match ID to enable.
               disable:
                 type: array
                 items:
                   type: string
+                  format: uuid
                   description: Match ID to disable.
     responses:
       "204":
@@ -188,9 +195,5 @@ new_report:
             schema:
               type: string
             description: Link to the newly generated report.
-        content:
-          application/json:
-            schema:
-              $ref: ../schemas/applicants/applicant.yaml
       default:
         $ref: ../responses/default_error.yaml

--- a/paths/watchlist_monitors.yaml
+++ b/paths/watchlist_monitors.yaml
@@ -9,10 +9,10 @@ watchlist_monitors:
       content:
         application/json:
           schema:
-            $ref: ../schemas/watchlist_monitors/watchlist_monitor.yaml
+            $ref: ../schemas/watchlist_monitors/watchlist_monitor_builder.yaml
     responses:
-      "200":
-        description: Created watchlist monitor
+      "201":
+        description: Created
         content:
           application/json:
             schema:
@@ -45,10 +45,15 @@ watchlist_monitors:
         content:
           application/json:
             schema:
-              type: array
-              title: Watchlist monitors
-              items:
-                $ref: ../schemas/watchlist_monitors/watchlist_monitor.yaml
+              type: object
+              title: Watchlist monitors list
+              required:
+                - monitors
+              properties:
+                monitors:
+                  type: array
+                  items:
+                    $ref: ../schemas/watchlist_monitors/watchlist_monitor.yaml
       default:
         $ref: ../responses/default_error.yaml
 

--- a/paths/watchlist_monitors.yaml
+++ b/paths/watchlist_monitors.yaml
@@ -118,28 +118,11 @@ matches:
         content:
           application/json:
             schema:
-              type: object
-              title: Watchlist monitor matches list
-              required:
-                - matches
-              properties:
-                matches:
-                  type: array
-                  items:
-                    type: object
-                    title: Watchlist monitor match
-                    properties:
-                      id:
-                        type: string
-                        format: uuid
-                        description: Monitor ID
-                      enabled:
-                        type: boolean
-                        description: Monitor status
+              $ref: ../schemas/watchlist_monitors/watchlist_monitor_matches_list.yaml
 
   patch:
     summary: Set match status (BETA)
-    operationId: update_monitor_match
+    operationId: update_watchlist_monitor_match
     description: >
       Update the status of the given matches
     parameters:
@@ -154,23 +137,14 @@ matches:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              enable:
-                type: array
-                items:
-                  type: string
-                  format: uuid
-                  description: Match ID to enable.
-              disable:
-                type: array
-                items:
-                  type: string
-                  format: uuid
-                  description: Match ID to disable.
+            $ref: ../schemas/watchlist_monitors/watchlist_monitor_matches_updater.yaml
     responses:
-      "204":
-        description: No Content
+      "200":
+        description: An array of watchlist monitors
+        content:
+          application/json:
+            schema:
+              $ref: ../schemas/watchlist_monitors/watchlist_monitor_matches_list.yaml
       default:
         $ref: ../responses/default_error.yaml
 

--- a/schemas/watchlist_monitors/definitions.yaml
+++ b/schemas/watchlist_monitors/definitions.yaml
@@ -13,7 +13,7 @@ watchlist_monitor_shared:
       enum:
         - watchlist_standard
         - watchlist_aml
-      description: The name of the report type the monitor creates. Can be either "watchlist_standard" or "watchlist_aml".
+      description: The name of the report type the monitor creates.
     tags:
       type: array
       items:

--- a/schemas/watchlist_monitors/definitions.yaml
+++ b/schemas/watchlist_monitors/definitions.yaml
@@ -1,0 +1,43 @@
+watchlist_monitor_shared:
+  type: object
+  required:
+    - applicant_id
+    - report_name
+  properties:
+    applicant_id:
+      type: string
+      format: uuid
+      description: The ID for the applicant associated with the monitor.
+    report_name:
+      type: string
+      enum:
+        - watchlist_standard
+        - watchlist_aml
+      description: The name of the report type the monitor creates. Can be either "watchlist_standard" or "watchlist_aml".
+    tags:
+      type: array
+      items:
+        type: string
+      description: A list of tags associated with this monitor. These tags will be applied to each check this monitor creates.
+
+watchlist_monitor_response:
+  type: object
+  required:
+    - id
+  properties:
+    id:
+      type: string
+      format: uuid
+      description: The unique identifier for the monitor.
+    created_at:
+      type: string
+      format: date-time
+      description: The date and time at which the monitor was created.
+    deleted_at:
+      type: string
+      format: date-time
+      description: The date and time at which the monitor was deleted. If the monitor is still active, this field will be null.
+    is_sandbox:
+      type: boolean
+      default: false
+      description: Indicates whether the object was created in the sandbox or not.

--- a/schemas/watchlist_monitors/watchlist_monitor_builder.yaml
+++ b/schemas/watchlist_monitors/watchlist_monitor_builder.yaml
@@ -1,3 +1,2 @@
 allOf:
   - $ref: definitions.yaml#/watchlist_monitor_shared
-  - $ref: definitions.yaml#/watchlist_monitor_response

--- a/schemas/watchlist_monitors/watchlist_monitor_matches_list.yaml
+++ b/schemas/watchlist_monitors/watchlist_monitor_matches_list.yaml
@@ -1,0 +1,18 @@
+type: object
+title: Watchlist monitor matches list
+required:
+  - matches
+properties:
+  matches:
+    type: array
+    items:
+      type: object
+      title: Watchlist monitor match
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Monitor ID
+        enabled:
+          type: boolean
+          description: Monitor status

--- a/schemas/watchlist_monitors/watchlist_monitor_matches_updater.yaml
+++ b/schemas/watchlist_monitors/watchlist_monitor_matches_updater.yaml
@@ -1,0 +1,14 @@
+type: object
+properties:
+  enable:
+    type: array
+    items:
+      type: string
+      format: uuid
+      description: Match ID to enable.
+  disable:
+    type: array
+    items:
+      type: string
+      format: uuid
+      description: Match ID to disable.


### PR DESCRIPTION
Improve and fix definition to match [watchlist_monitor endpoints](https://documentation.onfido.com/#create-monitor-request-body) behaviour. Main improvements:
- Create a watchlist_monitor_builder
- Rename `update_monitor_match` into `update_watchlist_monitor_match`

It includes a change in CI asked by DevOps.