### PR TITLE
[CAT-1120] Some fixes to OpenAPI spec and java templates

### DIFF
--- a/generators/java/okhttp-gson/templates/libraries/okhttp-gson/oneof_model.mustache
+++ b/generators/java/okhttp-gson/templates/libraries/okhttp-gson/oneof_model.mustache
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;  {{! Added import }}
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -77,8 +78,10 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                     // check if the actual instance is of the type `{{{dataType}}}`
                     if (value.getActualInstance() instanceof {{#isArray}}List<?>{{/isArray}}{{^isArray}}{{{dataType}}}{{/isArray}}) {
                     {{#isPrimitiveType}}
-                        JsonPrimitive primitive = adapter{{#sanitizeGeneric}}{{{dataType}}}{{/sanitizeGeneric}}.toJsonTree(({{{dataType}}})value.getActualInstance()).getAsJsonPrimitive();
-                        elementAdapter.write(out, primitive);
+                        {{! Updated code - BEGIN }}
+                        JsonElement element = adapter{{#sanitizeGeneric}}{{{dataType}}}{{/sanitizeGeneric}}.toJsonTree(({{{dataType}}})value.getActualInstance());
+                        elementAdapter.write(out, element);
+                        {{! Updated code - END }}
                         return;
                     {{/isPrimitiveType}}
                     {{^isPrimitiveType}}

--- a/generators/java/okhttp-gson/templates/libraries/okhttp-gson/pom.mustache
+++ b/generators/java/okhttp-gson/templates/libraries/okhttp-gson/pom.mustache
@@ -273,8 +273,6 @@
                     </plugin>
                 </plugins>
             </build>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 

--- a/paths/tasks.yaml
+++ b/paths/tasks.yaml
@@ -22,7 +22,7 @@ tasks:
               title: Tasks
               items:
                 type: object
-                title: Task
+                title: TaskItem
                 properties:
                   id:
                     $ref: ../schemas/tasks/definitions.yaml#/task_id

--- a/schemas/tasks/complete_task_builder.yaml
+++ b/schemas/tasks/complete_task_builder.yaml
@@ -4,9 +4,9 @@ required:
 properties:
   data:
     description: The Task completion payload.
-    title: Complete Task Builder Data
+    title: Complete Task Data Builder
     oneOf:
-      - type: object
       - type: array
         items:
           type: object
+      - type: object


### PR DESCRIPTION
- OpenAPI spec updates:
  - Rename objects returned from list_tasks method from `task` to `task_item` to avoid collision with the `task` object returned by the find_task method
  - Rename `Complete Task Builder Data` schema into `Complete Task Data Builder` for consistency
  - Swap List and Object to have proper order in generated code (from less to more specific, in Java at least)
- Java Templates updates:
  - include missing java.util.UUID import into oneof_model template
  - extract Objects and Lists included in a oneOf schema as `JsonElement` instead of `JsonPrimitive` (a _java.lang.IllegalStateException: Not a JSON Primitive_ exception would be raised otherwise) -> a PR to openapi generator will possibly be created
  - fix to pom.xml template to remove duplicated block closures