### PR TITLE
[CAT-1120] Improve readme, fix id photos list and regex in tasks definition

### DIFF
--- a/generators/java/okhttp-gson/templates/README.mustache
+++ b/generators/java/okhttp-gson/templates/README.mustache
@@ -143,11 +143,13 @@ Webhook events payload needs to be verified before it can be accessed. Library a
 
 ```java
 try {
-   WebhookEventVerifier verifier = new WebhookEventVerifier("_ABC123abc...3ABC123_");
+   WebhookEventVerifier verifier = new WebhookEventVerifier(
+      System.getenv("ONFIDO_WEBHOOK_SECRET_TOKEN")
+   );
 
    String signature = "a0...760e";
 
-   WebhookEvent event = verifier.readPayload("{\"payload\":{\"r...3\"}}}", signature);
+   WebhookEvent event = verifier.readPayload("{\"payload\":{\"r...3\"}}", signature);
 } catch( OnfidoInvalidSignatureError e ) {
    // Invalid webhook signature
 }

--- a/generators/php/templates/README.mustache
+++ b/generators/php/templates/README.mustache
@@ -94,7 +94,7 @@ Webhook events payload needs to be verified before it can be accessed. Library a
 
 ```php
 try {
-  $verifier = new Onfido\WebhookEventVerifier('_ABC123abc...3ABC123_');
+  $verifier = new Onfido\WebhookEventVerifier(getenv('ONFIDO_WEBHOOK_SECRET_TOKEN'));
 
   $signature = 'a0...760e';
 

--- a/generators/python/urllib3/templates/README.mustache
+++ b/generators/python/urllib3/templates/README.mustache
@@ -96,7 +96,7 @@ Webhook events payload needs to be verified before it can be accessed. Library a
 
 ```python
   try:
-    verifier = {{{packageName}}}.WebhookEventVerifier("_ABC123abc...3ABC123_")
+    verifier = {{{packageName}}}.WebhookEventVerifier(os.environ["ONFIDO_WEBHOOK_SECRET_TOKEN"])
 
     signature = "a0...760e"
 

--- a/generators/ruby/faraday/templates/README.mustache
+++ b/generators/ruby/faraday/templates/README.mustache
@@ -23,7 +23,7 @@ Configure with your API token, region and optional timeout (default value is 30)
 require {{{gemName}}}
 
 Onfido.configure do |config|
-  config.api_token = ENV["ONFIDO_API_TOKEN"]
+  config.api_token = ENV["ONFIDO_WEBHOOK_SECRET_TOKEN"]
   config.region = config.region[:EU]
   config.timeout = 30
 end
@@ -78,9 +78,9 @@ Webhook events payload needs to be verified before it can be accessed. Library a
     event = verifier.read_payload('{"payload":{"r...3"}}', signature)
 
   rescue Onfido::OnfidoInvalidSignatureError => e
-    e.type         
-    e.fields        
-    e.response_code 
+    e.type
+    e.fields
+    e.response_code
   end
 ```
 

--- a/generators/typescript-axios/templates/README.mustache
+++ b/generators/typescript-axios/templates/README.mustache
@@ -162,7 +162,8 @@ Webhook events payload needs to be verified before it can be accessed. Library a
 ```js
 (async () => {
   try {
-    const verifier = new WebhookEventVerifier("_ABC123abc...3ABC123_");
+    const token = process.env.ONFIDO_WEBHOOK_SECRET_TOKEN;
+    const verifier = new WebhookEventVerifier(token);
     const signature = "a0...760e";
 
     const event = verifier.readPayload(`{"payload":{"r...3"}}`, signature);

--- a/paths/id_photos.yaml
+++ b/paths/id_photos.yaml
@@ -19,7 +19,7 @@ id_photos:
           application/json:
             schema:
               type: object
-              title: ID Photos list
+              title: Id Photos list
               required:
                 - id_photos
               properties:

--- a/schemas/tasks/definitions.yaml
+++ b/schemas/tasks/definitions.yaml
@@ -1,10 +1,10 @@
 task_id:
   type: string
-  pattern: ^[0-9a-z-_]+$
+  pattern: ^[0-9a-z_-]+$
   description: The identifier for the Task.
   example: profile_123
 task_def_id:
   type: string
-  pattern: ^[0-9a-z-_]+$
+  pattern: ^[0-9a-z_-]+$
   description: The identifier for the Task Definition.
   example: task_123


### PR DESCRIPTION
Rename schema returned by `list_id_photos` operation from `ID Photos list` into `Id Photos list` for consistency as discussed in https://github.com/onfido/onfido-python/pull/58#issuecomment-2145156354.

Taking also the opportunity for replacing hardcoded value for webhook verification token inside templated README.md files into a value retrieved from environment.

Lastly fixing also warning below raised when running [ruby integration tests](https://github.com/onfido/onfido-ruby/actions/runs/9366368764/job/25783635293):
`warning: character class has '-' without escape: /^[0-9a-z-_]+$/`