### PR TITLE
[CAT-1241][Java] Add FileTransfer object to allow in-memory only file upload/download

### DIFF
--- a/generators/java/okhttp-gson/config.yaml
+++ b/generators/java/okhttp-gson/config.yaml
@@ -22,6 +22,8 @@ scmDeveloperConnection: scm:git:git://github.com/onfido/onfido-java.git
 scmUrl: https://github.com/onfido/onfido-java
 useOneOfDiscriminatorLookup: true
 legacyDiscriminatorBehavior: false
+typeMappings:
+  File: FileTransfer
 files:
   LICENSE.mustache:
     destinationFilename: LICENSE
@@ -29,3 +31,5 @@ files:
     destinationFilename: src/main/java/com/onfido/WebhookEventVerifier.java
   OnfidoInvalidSignatureError.mustache:
     destinationFilename: src/main/java/com/onfido/OnfidoInvalidSignatureError.java
+  FileTransfer.mustache:
+    destinationFilename: src/main/java/com/onfido/FileTransfer.java

--- a/generators/java/okhttp-gson/templates/FileTransfer.mustache
+++ b/generators/java/okhttp-gson/templates/FileTransfer.mustache
@@ -1,0 +1,160 @@
+{{>licenseInfo}}
+
+package {{invokerPackage}};
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLConnection;
+import java.nio.file.Files;
+
+public class FileTransfer  {
+  private static final long serialVersionUID = 1L;
+
+  private File file = null;
+  private byte[] bytes = null;
+  private String filename = null;
+  private String contentType = null;
+
+  /**
+   * Create a new file transfer using in-memory byte array
+   *
+   * @param bytes Byte array to include in file transfer
+   * @param filename Filename to send together with the transfer
+   * @throws ApiException
+   */
+  public FileTransfer(byte[] bytes, String filename) throws ApiException {
+    this(bytes, filename, null);
+  }
+
+  /**
+   * Create a new file transfer using in-memory byte array
+   *
+   * @param bytes Byte array to include in file transfer
+   * @param filename Filename to send together with the transfer
+   * @param contentType Content type to use for this file
+   * @throws ApiException
+   */
+  public FileTransfer(byte[] bytes, String filename, String contentType) throws ApiException {
+    this.bytes = bytes;
+    this.filename = filename;
+
+    updateContentType(contentType);
+  }
+
+  /**
+   * Create a new file transfer from a file store on disk
+   *
+   * @param file File to include in transfer
+   * @throws ApiException
+   */
+  public FileTransfer(File file) throws ApiException {
+    this(file, null);
+  }
+
+  /**
+   * @param file File to include in transfer
+   * @param contentType Content type to use for this file
+   * @throws ApiException
+   */
+  public FileTransfer(File file, String contentType) throws ApiException {
+    this.file = file;
+
+    updateContentType(contentType);
+  }
+
+  /**
+   * @return the file, if loaded from disk
+   */
+  public File getFile() {
+    return file;
+  }
+
+  /**
+   * @return the bytes, if loaded from memory (always the case for downloads)
+   */
+  public byte[] getBytes() {
+    return bytes;
+  }
+
+  /**
+   * @return the filename associated with this transfer
+   */
+  public String getFilename() {
+    return filename;
+  }
+
+  /**
+   * @return the content-type associated with this transfer
+   */
+  public String getContentType() {
+    return contentType;
+  }
+
+  /**
+   * @return the lenght of the file in bytes
+   */
+  public long length() {
+    if ( bytes != null ){
+      return bytes.length;
+    }
+    else if ( file != null ){
+      return file.length();
+    }
+    else {
+      return 0;
+    }
+  }
+
+  /**
+   * @param destination
+   * @throws ApiException
+   */
+  public void save(File destination) throws ApiException {
+    if ( bytes != null )
+    {
+      try (FileOutputStream outputStream = new FileOutputStream(destination)) {
+        outputStream.write(bytes);
+      } catch (IOException e) {
+        throw new ApiException(e);
+      }
+    }
+    else
+    {
+      throw new ApiException("No content to save");
+    }
+  }
+
+  private void updateContentType(String contentType) throws ApiException {
+    if (contentType != null) {
+      this.contentType = contentType;
+      return;
+    }
+
+    try {
+      InputStream heading = null;
+
+      if (file != null) {
+        heading = new BufferedInputStream(new FileInputStream(file), 16);
+        this.filename = file.getName();
+      } else if (bytes != null) {
+        heading = new ByteArrayInputStream(bytes, 0, 16);
+      } else {
+        this.contentType = null;
+        return;
+      }
+
+      this.contentType = URLConnection.guessContentTypeFromStream(heading);
+
+      if (this.contentType == null) {
+        this.contentType = URLConnection.guessContentTypeFromName(this.filename);
+      }
+    } catch (IOException e) {
+      throw new ApiException(e);
+    }
+  }
+}

--- a/generators/java/okhttp-gson/templates/FileTransfer.mustache
+++ b/generators/java/okhttp-gson/templates/FileTransfer.mustache
@@ -2,83 +2,77 @@
 
 package {{invokerPackage}};
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLConnection;
-import java.nio.file.Files;
 
-public class FileTransfer  {
-  private static final long serialVersionUID = 1L;
+public class FileTransfer {
 
-  private File file = null;
-  private byte[] bytes = null;
+  private File inputFile = null;
+  private byte[] byteArray = null;
   private String filename = null;
   private String contentType = null;
 
   /**
-   * Create a new file transfer using in-memory byte array
+   * Create a new file transfer from a byte array
    *
-   * @param bytes Byte array to include in file transfer
+   * @param byteArray Byte array to include in file transfer
    * @param filename Filename to send together with the transfer
    * @throws ApiException
    */
-  public FileTransfer(byte[] bytes, String filename) throws ApiException {
-    this(bytes, filename, null);
+  public FileTransfer(byte[] byteArray, String filename) {
+    this.byteArray = byteArray;
+
+    updateMetadata(filename);
   }
 
   /**
-   * Create a new file transfer using in-memory byte array
-   *
-   * @param bytes Byte array to include in file transfer
-   * @param filename Filename to send together with the transfer
-   * @param contentType Content type to use for this file
-   * @throws ApiException
-   */
-  public FileTransfer(byte[] bytes, String filename, String contentType) throws ApiException {
-    this.bytes = bytes;
-    this.filename = filename;
-
-    updateContentType(contentType);
-  }
-
-  /**
-   * Create a new file transfer from a file store on disk
+   * Create a new file transfer from a File
    *
    * @param file File to include in transfer
    * @throws ApiException
    */
-  public FileTransfer(File file) throws ApiException {
-    this(file, null);
+  public FileTransfer(File inputFile) {
+    this.inputFile = inputFile;
+
+    updateMetadata(inputFile.getName());
   }
 
   /**
-   * @param file File to include in transfer
-   * @param contentType Content type to use for this file
+   * Create a new file transfer from an InputStream
+   *
+   * @param inputStream InputStream to read data from
+   * @param filename Filename to send together with the transfer
    * @throws ApiException
    */
-  public FileTransfer(File file, String contentType) throws ApiException {
-    this.file = file;
+  public FileTransfer(InputStream inputStream, String filename) throws ApiException {
+    try {
+      this.byteArray = new byte[inputStream.available()];
+      inputStream.read(byteArray);
+    } catch (IOException e) {
+      throw new ApiException(e);
+    }
 
-    updateContentType(contentType);
+    updateMetadata(filename);
   }
 
   /**
-   * @return the file, if loaded from disk
+   * Return the array of bytes used for this file transfer.
+   *
+   * @return array of bytes
    */
-  public File getFile() {
-    return file;
+  public byte[] getByteArray() {
+    return byteArray;
   }
 
   /**
-   * @return the bytes, if loaded from memory (always the case for downloads)
+   * Return the input stream used for this file transfer
+   *
+   * @return the provided input file
    */
-  public byte[] getBytes() {
-    return bytes;
+  public File getInputFile() {
+    return inputFile;
   }
 
   /**
@@ -95,66 +89,8 @@ public class FileTransfer  {
     return contentType;
   }
 
-  /**
-   * @return the lenght of the file in bytes
-   */
-  public long length() {
-    if ( bytes != null ){
-      return bytes.length;
-    }
-    else if ( file != null ){
-      return file.length();
-    }
-    else {
-      return 0;
-    }
-  }
-
-  /**
-   * @param destination
-   * @throws ApiException
-   */
-  public void save(File destination) throws ApiException {
-    if ( bytes != null )
-    {
-      try (FileOutputStream outputStream = new FileOutputStream(destination)) {
-        outputStream.write(bytes);
-      } catch (IOException e) {
-        throw new ApiException(e);
-      }
-    }
-    else
-    {
-      throw new ApiException("No content to save");
-    }
-  }
-
-  private void updateContentType(String contentType) throws ApiException {
-    if (contentType != null) {
-      this.contentType = contentType;
-      return;
-    }
-
-    try {
-      InputStream heading = null;
-
-      if (file != null) {
-        heading = new BufferedInputStream(new FileInputStream(file), 16);
-        this.filename = file.getName();
-      } else if (bytes != null) {
-        heading = new ByteArrayInputStream(bytes, 0, 16);
-      } else {
-        this.contentType = null;
-        return;
-      }
-
-      this.contentType = URLConnection.guessContentTypeFromStream(heading);
-
-      if (this.contentType == null) {
-        this.contentType = URLConnection.guessContentTypeFromName(this.filename);
-      }
-    } catch (IOException e) {
-      throw new ApiException(e);
-    }
+  private void updateMetadata(String filename) {
+    this.contentType = URLConnection.guessContentTypeFromName(filename);
+    this.filename = filename;
   }
 }

--- a/generators/java/okhttp-gson/templates/FileTransfer.mustache
+++ b/generators/java/okhttp-gson/templates/FileTransfer.mustache
@@ -1,5 +1,3 @@
-{{>licenseInfo}}
-
 package {{invokerPackage}};
 
 import java.io.File;

--- a/generators/java/okhttp-gson/templates/OnfidoInvalidSignatureError.mustache
+++ b/generators/java/okhttp-gson/templates/OnfidoInvalidSignatureError.mustache
@@ -1,4 +1,4 @@
-package com.onfido;
+package {{invokerPackage}};
 
 public class OnfidoInvalidSignatureError extends Exception {
   public OnfidoInvalidSignatureError(String message, Throwable cause) {

--- a/generators/java/okhttp-gson/templates/SHA256SUM
+++ b/generators/java/okhttp-gson/templates/SHA256SUM
@@ -1,5 +1,6 @@
 
 16502193337397367078434a27f67edfc6410f4c06d12db876155885d6a49394  ./README.mustache
 7b635a5f3fcc4cb2ace38f0dd0ca8252a78090e592a6c35fe5a08f7bc407ef6b  ./libraries/okhttp-gson/ApiClient.mustache
+133ba02513dba3fa805f364770b5a2fcc87a4c6ed0cf7afd322376e03143859f  ./libraries/okhttp-gson/api.mustache
 0e77feaf2d6b0818194161ac7e621189aa6e7900b45d46fa4ff1232894bb1a7a  ./libraries/okhttp-gson/oneof_model.mustache
 e83ff873cc6a5a7e064b4732ab4bfbb3fa32660d015b9ca1b6bdb5884335c506  ./libraries/okhttp-gson/pom.mustache

--- a/generators/java/okhttp-gson/templates/WebhookEventVerifier.mustache
+++ b/generators/java/okhttp-gson/templates/WebhookEventVerifier.mustache
@@ -1,4 +1,4 @@
-package com.onfido;
+package {{invokerPackage}};
 
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.FieldNamingStrategy;

--- a/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
+++ b/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
@@ -1089,6 +1089,13 @@ public class ApiClient {
         } else if (returnType.equals(File.class)) {
             // Handle file downloading.
             return (T) downloadFileFromResponse(response);
+        {{! Extra else block added to handle FileTransfer class }}
+        } else if (returnType.equals(FileTransfer.class)) {
+            try {
+                return (T) new FileTransfer(response.body().bytes(), "");
+            } catch (IOException e) {
+                throw new ApiException(e);
+            }
         }
 
         String respBody;
@@ -1602,14 +1609,18 @@ public class ApiClient {
     public RequestBody buildRequestBodyMultipart(Map<String, Object> formParams) {
         MultipartBody.Builder mpBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM);
         for (Entry<String, Object> param : formParams.entrySet()) {
-            if (param.getValue() instanceof File) {
-                File file = (File) param.getValue();
+            {{! Code updated to handle FileTransfer class - BEGIN }}
+            if (param.getValue() instanceof FileTransfer) {
+                FileTransfer file = (FileTransfer) param.getValue();
+                {{! Code updated to handle FileTransfer class - END }}
                 addPartToMultiPartBuilder(mpBuilder, param.getKey(), file);
             } else if (param.getValue() instanceof List) {
                 List list = (List) param.getValue();
                 for (Object item: list) {
-                    if (item instanceof File) {
-                        addPartToMultiPartBuilder(mpBuilder, param.getKey(), (File) item);
+                    {{! Code updated to handle FileTransfer class - BEGIN }}
+                    if (item instanceof FileTransfer) {
+                        addPartToMultiPartBuilder(mpBuilder, param.getKey(), (FileTransfer) item);
+                        {{! Code updated to handle FileTransfer class - END }}
                     } else {
                         addPartToMultiPartBuilder(mpBuilder, param.getKey(), param.getValue());
                     }
@@ -1621,21 +1632,7 @@ public class ApiClient {
         return mpBuilder.build();
     }
 
-    /**
-     * Guess Content-Type header from the given file (defaults to "application/octet-stream").
-     *
-     * @param file The given file
-     * @return The guessed Content-Type
-     */
-    public String guessContentTypeFromFile(File file) {
-        String contentType = URLConnection.guessContentTypeFromName(file.getName());
-        if (contentType == null) {
-            return "application/octet-stream";
-        } else {
-            return contentType;
-        }
-    }
-
+    {{! guessContentTypeFromFile dropped (part of FileTransfer now) }}
     /**
      * Add a Content-Disposition Header for the given key and file to the MultipartBody Builder.
      *
@@ -1643,10 +1640,15 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
-        Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
-        MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
-        mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
+    {{! function updated to accept a FileTransfer object }}
+    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, FileTransfer file) {
+        Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getFilename() + "\"");
+        MediaType mediaType = MediaType.parse(file.getContentType());
+        if (file.getBytes() != null) {
+            mpBuilder.addPart(partHeaders, RequestBody.create(file.getBytes(), mediaType));
+        } else {
+            mpBuilder.addPart(partHeaders, RequestBody.create(file.getFile(), mediaType));
+        }
     }
 
     /**
@@ -1660,10 +1662,10 @@ public class ApiClient {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
-        {{! TODO submit a bugfix - BEGIN }}
+        {{! Code fixed, submit a bugfix - BEGIN }}
         } else if (obj instanceof UUID || obj instanceof Enum) {
             requestBody = RequestBody.create(obj.toString(), MediaType.parse("text/plain"));
-        {{! TODO submit a bugfix - END }}
+        {{! Code fixed, submit a bugfix - END }}
         } else {
             String content;
             if (obj != null) {

--- a/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
+++ b/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
@@ -1089,6 +1089,14 @@ public class ApiClient {
         } else if (returnType.equals(File.class)) {
             // Handle file downloading.
             return (T) downloadFileFromResponse(response);
+        {{! Extra else block added to handle FileTransfer class }}
+        } else if (returnType.equals(FileTransfer.class)) {
+            try {
+                String filename = getFilenameFromResponse(response);
+                return (T) new FileTransfer(response.body().bytes(), filename);
+            } catch (IOException e) {
+                throw new ApiException(e);
+            }
         }
 
         String respBody;
@@ -1184,16 +1192,8 @@ public class ApiClient {
      * @throws java.io.IOException If fail to prepare file for download
      */
     public File prepareDownloadFile(Response response) throws IOException {
-        String filename = null;
-        String contentDisposition = response.header("Content-Disposition");
-        if (contentDisposition != null && !"".equals(contentDisposition)) {
-            // Get filename from the Content-Disposition header.
-            Pattern pattern = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
-            Matcher matcher = pattern.matcher(contentDisposition);
-            if (matcher.find()) {
-                filename = sanitizeFilename(matcher.group(1));
-            }
-        }
+        {{! Code extrated to getFilenameFromResponse }}
+        String filename = getFilenameFromResponse(response);
 
         String prefix = null;
         String suffix = null;
@@ -1602,14 +1602,18 @@ public class ApiClient {
     public RequestBody buildRequestBodyMultipart(Map<String, Object> formParams) {
         MultipartBody.Builder mpBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM);
         for (Entry<String, Object> param : formParams.entrySet()) {
-            if (param.getValue() instanceof File) {
-                File file = (File) param.getValue();
+            {{! Code updated to handle FileTransfer class - BEGIN }}
+            if (param.getValue() instanceof FileTransfer) {
+                FileTransfer file = (FileTransfer) param.getValue();
+                {{! Code updated to handle FileTransfer class - END }}
                 addPartToMultiPartBuilder(mpBuilder, param.getKey(), file);
             } else if (param.getValue() instanceof List) {
                 List list = (List) param.getValue();
                 for (Object item: list) {
-                    if (item instanceof File) {
-                        addPartToMultiPartBuilder(mpBuilder, param.getKey(), (File) item);
+                    {{! Code updated to handle FileTransfer class - BEGIN }}
+                    if (item instanceof FileTransfer) {
+                        addPartToMultiPartBuilder(mpBuilder, param.getKey(), (FileTransfer) item);
+                        {{! Code updated to handle FileTransfer class - END }}
                     } else {
                         addPartToMultiPartBuilder(mpBuilder, param.getKey(), param.getValue());
                     }
@@ -1621,21 +1625,7 @@ public class ApiClient {
         return mpBuilder.build();
     }
 
-    /**
-     * Guess Content-Type header from the given file (defaults to "application/octet-stream").
-     *
-     * @param file The given file
-     * @return The guessed Content-Type
-     */
-    public String guessContentTypeFromFile(File file) {
-        String contentType = URLConnection.guessContentTypeFromName(file.getName());
-        if (contentType == null) {
-            return "application/octet-stream";
-        } else {
-            return contentType;
-        }
-    }
-
+    {{! guessContentTypeFromFile dropped (part of FileTransfer now) }}
     /**
      * Add a Content-Disposition Header for the given key and file to the MultipartBody Builder.
      *
@@ -1643,10 +1633,35 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
-        Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
-        MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
-        mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
+    {{! function updated to accept a FileTransfer object }}
+    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, FileTransfer file) {
+        Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getFilename() + "\"");
+        MediaType mediaType = MediaType.parse(file.getContentType());
+
+        if ( file.getByteArray() != null ) {
+            mpBuilder.addPart(partHeaders, RequestBody.create(file.getByteArray(), mediaType));
+        }
+        else {
+            mpBuilder.addPart(partHeaders, RequestBody.create(file.getInputFile(), mediaType));
+        }
+    }
+
+    /**
+     * Retrieve filename, once santized, from provided response.
+     */
+    {{! code extracted from prepareDownloadFile function }}
+    private String getFilenameFromResponse(Response response) {
+        String filename = "";
+        String contentDisposition = response.header("Content-Disposition");
+        if (contentDisposition != null && !"".equals(contentDisposition)) {
+            // Get filename from the Content-Disposition header.
+            Pattern pattern = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
+            Matcher matcher = pattern.matcher(contentDisposition);
+            if (matcher.find()) {
+                filename = sanitizeFilename(matcher.group(1));
+            }
+        }
+        return filename;
     }
 
     /**
@@ -1660,10 +1675,10 @@ public class ApiClient {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
-        {{! TODO submit a bugfix - BEGIN }}
+        {{! Code fixed, submit a bugfix - BEGIN }}
         } else if (obj instanceof UUID || obj instanceof Enum) {
             requestBody = RequestBody.create(obj.toString(), MediaType.parse("text/plain"));
-        {{! TODO submit a bugfix - END }}
+        {{! Code fixed, submit a bugfix - END }}
         } else {
             String content;
             if (obj != null) {

--- a/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
+++ b/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
@@ -1092,7 +1092,8 @@ public class ApiClient {
         {{! Extra else block added to handle FileTransfer class }}
         } else if (returnType.equals(FileTransfer.class)) {
             try {
-                return (T) new FileTransfer(response.body().bytes(), "");
+                String filename = getFilenameFromResponse(response);
+                return (T) new FileTransfer(response.body().bytes(), filename);
             } catch (IOException e) {
                 throw new ApiException(e);
             }
@@ -1191,16 +1192,8 @@ public class ApiClient {
      * @throws java.io.IOException If fail to prepare file for download
      */
     public File prepareDownloadFile(Response response) throws IOException {
-        String filename = null;
-        String contentDisposition = response.header("Content-Disposition");
-        if (contentDisposition != null && !"".equals(contentDisposition)) {
-            // Get filename from the Content-Disposition header.
-            Pattern pattern = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
-            Matcher matcher = pattern.matcher(contentDisposition);
-            if (matcher.find()) {
-                filename = sanitizeFilename(matcher.group(1));
-            }
-        }
+        {{! Code extrated to getFilenameFromResponse }}
+        String filename = getFilenameFromResponse(response);
 
         String prefix = null;
         String suffix = null;
@@ -1651,6 +1644,24 @@ public class ApiClient {
         else {
             mpBuilder.addPart(partHeaders, RequestBody.create(file.getInputFile(), mediaType));
         }
+    }
+
+    /**
+     * Retrieve filename, once santized, from provided response.
+     */
+    {{! code extracted from prepareDownloadFile function }}
+    private String getFilenameFromResponse(Response response) {
+        String filename = "";
+        String contentDisposition = response.header("Content-Disposition");
+        if (contentDisposition != null && !"".equals(contentDisposition)) {
+            // Get filename from the Content-Disposition header.
+            Pattern pattern = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
+            Matcher matcher = pattern.matcher(contentDisposition);
+            if (matcher.find()) {
+                filename = sanitizeFilename(matcher.group(1));
+            }
+        }
+        return filename;
     }
 
     /**

--- a/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
+++ b/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
@@ -1644,10 +1644,12 @@ public class ApiClient {
     private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, FileTransfer file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getFilename() + "\"");
         MediaType mediaType = MediaType.parse(file.getContentType());
-        if (file.getBytes() != null) {
-            mpBuilder.addPart(partHeaders, RequestBody.create(file.getBytes(), mediaType));
-        } else {
-            mpBuilder.addPart(partHeaders, RequestBody.create(file.getFile(), mediaType));
+
+        if ( file.getByteArray() != null ) {
+            mpBuilder.addPart(partHeaders, RequestBody.create(file.getByteArray(), mediaType));
+        }
+        else {
+            mpBuilder.addPart(partHeaders, RequestBody.create(file.getInputFile(), mediaType));
         }
     }
 

--- a/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
+++ b/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
@@ -1089,14 +1089,6 @@ public class ApiClient {
         } else if (returnType.equals(File.class)) {
             // Handle file downloading.
             return (T) downloadFileFromResponse(response);
-        {{! Extra else block added to handle FileTransfer class }}
-        } else if (returnType.equals(FileTransfer.class)) {
-            try {
-                String filename = getFilenameFromResponse(response);
-                return (T) new FileTransfer(response.body().bytes(), filename);
-            } catch (IOException e) {
-                throw new ApiException(e);
-            }
         }
 
         String respBody;
@@ -1192,8 +1184,16 @@ public class ApiClient {
      * @throws java.io.IOException If fail to prepare file for download
      */
     public File prepareDownloadFile(Response response) throws IOException {
-        {{! Code extrated to getFilenameFromResponse }}
-        String filename = getFilenameFromResponse(response);
+        String filename = null;
+        String contentDisposition = response.header("Content-Disposition");
+        if (contentDisposition != null && !"".equals(contentDisposition)) {
+            // Get filename from the Content-Disposition header.
+            Pattern pattern = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
+            Matcher matcher = pattern.matcher(contentDisposition);
+            if (matcher.find()) {
+                filename = sanitizeFilename(matcher.group(1));
+            }
+        }
 
         String prefix = null;
         String suffix = null;
@@ -1602,18 +1602,14 @@ public class ApiClient {
     public RequestBody buildRequestBodyMultipart(Map<String, Object> formParams) {
         MultipartBody.Builder mpBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM);
         for (Entry<String, Object> param : formParams.entrySet()) {
-            {{! Code updated to handle FileTransfer class - BEGIN }}
-            if (param.getValue() instanceof FileTransfer) {
-                FileTransfer file = (FileTransfer) param.getValue();
-                {{! Code updated to handle FileTransfer class - END }}
+            if (param.getValue() instanceof File) {
+                File file = (File) param.getValue();
                 addPartToMultiPartBuilder(mpBuilder, param.getKey(), file);
             } else if (param.getValue() instanceof List) {
                 List list = (List) param.getValue();
                 for (Object item: list) {
-                    {{! Code updated to handle FileTransfer class - BEGIN }}
-                    if (item instanceof FileTransfer) {
-                        addPartToMultiPartBuilder(mpBuilder, param.getKey(), (FileTransfer) item);
-                        {{! Code updated to handle FileTransfer class - END }}
+                    if (item instanceof File) {
+                        addPartToMultiPartBuilder(mpBuilder, param.getKey(), (File) item);
                     } else {
                         addPartToMultiPartBuilder(mpBuilder, param.getKey(), param.getValue());
                     }
@@ -1625,7 +1621,21 @@ public class ApiClient {
         return mpBuilder.build();
     }
 
-    {{! guessContentTypeFromFile dropped (part of FileTransfer now) }}
+    /**
+     * Guess Content-Type header from the given file (defaults to "application/octet-stream").
+     *
+     * @param file The given file
+     * @return The guessed Content-Type
+     */
+    public String guessContentTypeFromFile(File file) {
+        String contentType = URLConnection.guessContentTypeFromName(file.getName());
+        if (contentType == null) {
+            return "application/octet-stream";
+        } else {
+            return contentType;
+        }
+    }
+
     /**
      * Add a Content-Disposition Header for the given key and file to the MultipartBody Builder.
      *
@@ -1633,35 +1643,10 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */
-    {{! function updated to accept a FileTransfer object }}
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, FileTransfer file) {
-        Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getFilename() + "\"");
-        MediaType mediaType = MediaType.parse(file.getContentType());
-
-        if ( file.getByteArray() != null ) {
-            mpBuilder.addPart(partHeaders, RequestBody.create(file.getByteArray(), mediaType));
-        }
-        else {
-            mpBuilder.addPart(partHeaders, RequestBody.create(file.getInputFile(), mediaType));
-        }
-    }
-
-    /**
-     * Retrieve filename, once santized, from provided response.
-     */
-    {{! code extracted from prepareDownloadFile function }}
-    private String getFilenameFromResponse(Response response) {
-        String filename = "";
-        String contentDisposition = response.header("Content-Disposition");
-        if (contentDisposition != null && !"".equals(contentDisposition)) {
-            // Get filename from the Content-Disposition header.
-            Pattern pattern = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
-            Matcher matcher = pattern.matcher(contentDisposition);
-            if (matcher.find()) {
-                filename = sanitizeFilename(matcher.group(1));
-            }
-        }
-        return filename;
+    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+        Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
+        MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
+        mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
     }
 
     /**
@@ -1675,10 +1660,10 @@ public class ApiClient {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
-        {{! Code fixed, submit a bugfix - BEGIN }}
+        {{! TODO submit a bugfix - BEGIN }}
         } else if (obj instanceof UUID || obj instanceof Enum) {
             requestBody = RequestBody.create(obj.toString(), MediaType.parse("text/plain"));
-        {{! Code fixed, submit a bugfix - END }}
+        {{! TODO submit a bugfix - END }}
         } else {
             String content;
             if (obj != null) {

--- a/generators/java/okhttp-gson/templates/libraries/okhttp-gson/api.mustache
+++ b/generators/java/okhttp-gson/templates/libraries/okhttp-gson/api.mustache
@@ -1,0 +1,597 @@
+{{>licenseInfo}}
+
+package {{package}};
+
+import {{invokerPackage}}.ApiCallback;
+import {{invokerPackage}}.ApiClient;
+import {{invokerPackage}}.ApiException;
+{{#dynamicOperations}}
+import {{invokerPackage}}.ApiOperation;
+{{/dynamicOperations}}
+import {{invokerPackage}}.ApiResponse;
+import {{invokerPackage}}.Configuration;
+import {{invokerPackage}}.Pair;
+import {{invokerPackage}}.ProgressRequestBody;
+import {{invokerPackage}}.ProgressResponseBody;
+import {{invokerPackage}}.FileTransfer;{{! Added import }}
+{{#performBeanValidation}}
+import {{invokerPackage}}.BeanValidationException;
+{{/performBeanValidation}}
+
+import com.google.gson.reflect.TypeToken;
+{{#dynamicOperations}}
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.parameters.Parameter;
+{{/dynamicOperations}}
+
+import java.io.IOException;
+
+{{#useBeanValidation}}
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
+{{/useBeanValidation}}
+{{#performBeanValidation}}
+import {{javaxPackage}}.validation.ConstraintViolation;
+import {{javaxPackage}}.validation.Validation;
+import {{javaxPackage}}.validation.ValidatorFactory;
+import {{javaxPackage}}.validation.executable.ExecutableValidator;
+import java.util.Set;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+{{/performBeanValidation}}
+
+{{#imports}}import {{import}};
+{{/imports}}
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+{{#supportStreaming}}
+import java.io.InputStream;
+{{/supportStreaming}}
+
+{{#operations}}
+public class {{classname}} {
+    private ApiClient localVarApiClient;
+    private int localHostIndex;
+    private String localCustomBaseUrl;
+
+    public {{classname}}() {
+        this(Configuration.getDefaultApiClient());
+    }
+
+    public {{classname}}(ApiClient apiClient) {
+        this.localVarApiClient = apiClient;
+    }
+
+    public ApiClient getApiClient() {
+        return localVarApiClient;
+    }
+
+    public void setApiClient(ApiClient apiClient) {
+        this.localVarApiClient = apiClient;
+    }
+
+    public int getHostIndex() {
+        return localHostIndex;
+    }
+
+    public void setHostIndex(int hostIndex) {
+        this.localHostIndex = hostIndex;
+    }
+
+    public String getCustomBaseUrl() {
+        return localCustomBaseUrl;
+    }
+
+    public void setCustomBaseUrl(String customBaseUrl) {
+        this.localCustomBaseUrl = customBaseUrl;
+    }
+
+    {{#operation}}
+    {{^vendorExtensions.x-group-parameters}}/**
+     * Build call for {{operationId}}{{#allParams}}
+     * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{^isContainer}}{{#defaultValue}}, default to {{.}}{{/defaultValue}}{{/isContainer}}){{/required}}{{/allParams}}
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     {{#responses.0}}
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        {{#responses}}
+        <tr><td> {{code}} </td><td> {{message}} </td><td> {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} </td></tr>
+        {{/responses}}
+     </table>
+     {{/responses.0}}
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
+        {{#externalDocs}}
+     * {{description}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
+        {{/externalDocs}}
+     */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
+    public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} okhttp3.Call {{operationId}}Call({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] { {{#servers}}"{{{url}}}"{{^-last}}, {{/-last}}{{/servers}} };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
+
+        // create path and map variables
+        {{^dynamicOperations}}
+        String localVarPath = "{{{path}}}"{{#pathParams}}
+            .replace("{" + "{{baseName}}" + "}", localVarApiClient.escapeString({{#collectionFormat}}localVarApiClient.collectionPathParameterToString("{{{collectionFormat}}}", {{{paramName}}}){{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}.toString(){{/collectionFormat}})){{/pathParams}};
+        {{/dynamicOperations}}
+        {{#dynamicOperations}}
+        ApiOperation apiOperation = localVarApiClient.getOperationLookupMap().get("{{{operationId}}}");
+        if (apiOperation == null) {
+            throw new ApiException("Operation not found in OAS");
+        }
+        Operation operation = apiOperation.getOperation();
+        String localVarPath = apiOperation.getPath();
+        Map<String, Object> paramMap = new HashMap<>();
+        {{#allParams}}
+            {{^isFormParam}}
+            {{^isBodyParam}}
+        paramMap.put("{{baseName}}", {{paramName}});
+            {{/isBodyParam}}
+            {{/isFormParam}}
+        {{/allParams}}
+        {{/dynamicOperations}}
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        {{#formParams}}
+        if ({{paramName}} != null) {
+            localVarFormParams.put("{{baseName}}", {{paramName}});
+        }
+
+        {{/formParams}}
+        {{^dynamicOperations}}
+        {{#queryParams}}
+        if ({{paramName}} != null) {
+            {{#collectionFormat}}localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("{{{.}}}", {{/collectionFormat}}{{^collectionFormat}}localVarQueryParams.addAll(localVarApiClient.parameterToPair({{/collectionFormat}}"{{baseName}}", {{paramName}}));
+        }
+
+        {{/queryParams}}
+        {{#constantParams}}
+        {{#isQueryParam}}
+        // Set client side default value of Query Param "{{baseName}}".
+        localVarCollectionQueryParams.add(new Pair("{{baseName}}", {{#_enum}}"{{{.}}}"{{/_enum}}));
+
+        {{/isQueryParam}}
+        {{/constantParams}}
+        {{#headerParams}}
+        if ({{paramName}} != null) {
+            localVarHeaderParams.put("{{baseName}}", localVarApiClient.parameterToString({{paramName}}));
+        }
+
+        {{/headerParams}}
+        {{#constantParams}}
+        {{#isHeaderParam}}
+        // Set client side default value of Header Param "{{baseName}}".
+        localVarHeaderParams.put("{{baseName}}", {{#_enum}}"{{{.}}}"{{/_enum}});
+
+        {{/isHeaderParam}}
+        {{/constantParams}}
+        {{#cookieParams}}
+        if ({{paramName}} != null) {
+            localVarCookieParams.put("{{baseName}}", localVarApiClient.parameterToString({{paramName}}));
+        }
+
+        {{/cookieParams}}
+        {{#constantParams}}
+        {{#isCookieParam}}
+        // Set client side default value of Cookie Param "{{baseName}}".
+        localVarCookieParams.put("{{baseName}}", {{#_enum}}"{{{.}}}"{{/_enum}});
+
+        {{/isCookieParam}}
+        {{/constantParams}}
+        {{/dynamicOperations}}
+        {{#dynamicOperations}}
+        localVarPath = localVarApiClient.fillParametersFromOperation(operation, paramMap, localVarPath, localVarQueryParams, localVarCollectionQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        {{/dynamicOperations}}
+        final String[] localVarAccepts = {
+            {{#produces}}
+            "{{{mediaType}}}"{{^-last}},{{/-last}}
+            {{/produces}}
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+            {{#consumes}}
+            "{{{mediaType}}}"{{^-last}},{{/-last}}
+            {{/consumes}}
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] { {{#withAWSV4Signature}}"AWS4Auth"{{/withAWSV4Signature}}{{#authMethods}}{{#-first}}{{#withAWSV4Signature}}, {{/withAWSV4Signature}}{{/-first}}"{{name}}"{{^-last}}, {{/-last}}{{/authMethods}} };
+        return localVarApiClient.buildCall(basePath, localVarPath, {{^dynamicOperations}}"{{httpMethod}}"{{/dynamicOperations}}{{#dynamicOperations}}apiOperation.getMethod(){{/dynamicOperations}}, localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call {{operationId}}ValidateBeforeCall({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}final ApiCallback _callback) throws ApiException {
+        {{^performBeanValidation}}
+        {{#allParams}}
+        {{#required}}
+        // verify the required parameter '{{paramName}}' is set
+        if ({{paramName}} == null) {
+            throw new ApiException("Missing the required parameter '{{paramName}}' when calling {{operationId}}(Async)");
+        }
+
+        {{/required}}
+        {{/allParams}}
+        return {{operationId}}Call({{#allParams}}{{paramName}}, {{/allParams}}_callback);
+
+        {{/performBeanValidation}}
+        {{#performBeanValidation}}
+        try {
+            ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+            ExecutableValidator executableValidator = factory.getValidator().forExecutables();
+
+            Object[] parameterValues = { {{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}} };
+            Method method = this.getClass().getMethod("{{operationId}}WithHttpInfo"{{#allParams}}, {{#isArray}}java.util.List{{/isArray}}{{#isMap}}java.util.Map{{/isMap}}{{^isArray}}{{^isMap}}{{{dataType}}}{{/isMap}}{{/isArray}}.class{{/allParams}});
+            Set<ConstraintViolation<{{classname}}>> violations = executableValidator.validateParameters(this, method,
+                    parameterValues);
+
+            if (violations.size() == 0) {
+                return {{operationId}}Call({{#allParams}}{{paramName}}, {{/allParams}}_callback);
+            } else {
+                throw new BeanValidationException((Set) violations);
+            }
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+            throw new ApiException(e.getMessage());
+        } catch (SecurityException e) {
+            e.printStackTrace();
+            throw new ApiException(e.getMessage());
+        }
+        {{/performBeanValidation}}
+    }
+
+    {{^vendorExtensions.x-group-parameters}}
+    /**
+     * {{summary}}
+     * {{notes}}{{#allParams}}
+     * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{^isContainer}}{{#defaultValue}}, default to {{.}}{{/defaultValue}}{{/isContainer}}){{/required}}{{/allParams}}{{#returnType}}
+     * @return {{.}}{{/returnType}}
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     {{#responses.0}}
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        {{#responses}}
+        <tr><td> {{code}} </td><td> {{message}} </td><td> {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} </td></tr>
+        {{/responses}}
+     </table>
+     {{/responses.0}}
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
+        {{#externalDocs}}
+     * {{description}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
+        {{/externalDocs}}
+     */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
+    {{#vendorExtensions.x-streaming}}
+    public {{#returnType}}InputStream {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
+        {{#returnType}}InputStream localVarResp = {{/returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});{{#returnType}}
+        return localVarResp;{{/returnType}}
+    }
+    {{/vendorExtensions.x-streaming}}
+    {{^vendorExtensions.x-streaming}}
+    public {{#returnType}}{{{.}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
+        {{#returnType}}ApiResponse<{{{.}}}> localVarResp = {{/returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});{{#returnType}}
+        return localVarResp.getData();{{/returnType}}
+    }
+    {{/vendorExtensions.x-streaming}}
+    {{/vendorExtensions.x-group-parameters}}
+
+    {{^vendorExtensions.x-group-parameters}}/**
+     * {{summary}}
+     * {{notes}}{{#allParams}}
+     * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{^isContainer}}{{#defaultValue}}, default to {{.}}{{/defaultValue}}{{/isContainer}}){{/required}}{{/allParams}}
+     * @return ApiResponse&lt;{{returnType}}{{^returnType}}Void{{/returnType}}&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     {{#responses.0}}
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        {{#responses}}
+        <tr><td> {{code}} </td><td> {{message}} </td><td> {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} </td></tr>
+        {{/responses}}
+     </table>
+     {{/responses.0}}
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
+        {{#externalDocs}}
+     * {{description}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
+        {{/externalDocs}}
+     */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
+    public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-streaming}} InputStream {{operationId}}WithHttpInfo({{#allParams}}{{#useBeanValidation}}{{>beanValidationQueryParams}}{{/useBeanValidation}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
+        okhttp3.Call localVarCall = {{operationId}}ValidateBeforeCall({{#allParams}}{{paramName}}, {{/allParams}}null);
+        {{#returnType}}
+        {{#errorObjectType}}
+        try {
+            Type localVarReturnType = new TypeToken<{{{returnType}}}>(){}.getType();
+            return localVarApiClient.executeStream(localVarCall, localVarReturnType);
+        } catch (ApiException e) {
+            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<{{{errorObjectType}}}>(){}.getType()));
+            throw e;
+        }
+        {{/errorObjectType}}
+        {{^errorObjectType}}
+        Type localVarReturnType = new TypeToken<{{{returnType}}}>(){}.getType();
+        return localVarApiClient.executeStream(localVarCall, localVarReturnType);
+        {{/errorObjectType}}
+        {{/returnType}}
+    }
+    {{/vendorExtensions.x-streaming}}{{^vendorExtensions.x-streaming}} ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{#useBeanValidation}}{{>beanValidationQueryParams}}{{/useBeanValidation}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
+        okhttp3.Call localVarCall = {{operationId}}ValidateBeforeCall({{#allParams}}{{paramName}}, {{/allParams}}null);
+        {{^returnType}}
+        return localVarApiClient.execute(localVarCall);
+        {{/returnType}}
+        {{#returnType}}
+        {{#errorObjectType}}
+        try {
+            Type localVarReturnType = new TypeToken<{{{returnType}}}>(){}.getType();
+            return localVarApiClient.execute(localVarCall, localVarReturnType);
+        } catch (ApiException e) {
+            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<{{{errorObjectType}}}>(){}.getType()));
+            throw e;
+        }
+        {{/errorObjectType}}
+        {{^errorObjectType}}
+        Type localVarReturnType = new TypeToken<{{{returnType}}}>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+        {{/errorObjectType}}
+        {{/returnType}}
+    }
+    {{/vendorExtensions.x-streaming}}
+
+    {{^vendorExtensions.x-group-parameters}}/**
+     * {{summary}} (asynchronously)
+     * {{notes}}{{#allParams}}
+     * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{^isContainer}}{{#defaultValue}}, default to {{.}}{{/defaultValue}}{{/isContainer}}){{/required}}{{/allParams}}
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     {{#responses.0}}
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        {{#responses}}
+        <tr><td> {{code}} </td><td> {{message}} </td><td> {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} </td></tr>
+        {{/responses}}
+     </table>
+     {{/responses.0}}
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
+        {{#externalDocs}}
+     * {{description}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
+        {{/externalDocs}}
+     */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
+    public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} okhttp3.Call {{operationId}}Async({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}final ApiCallback<{{{returnType}}}{{^returnType}}Void{{/returnType}}> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = {{operationId}}ValidateBeforeCall({{#allParams}}{{paramName}}, {{/allParams}}_callback);
+        {{#returnType}}Type localVarReturnType = new TypeToken<{{{returnType}}}>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);{{/returnType}}{{^returnType}}localVarApiClient.executeAsync(localVarCall, _callback);{{/returnType}}
+        return localVarCall;
+    }
+    {{#vendorExtensions.x-group-parameters}}
+
+    public class API{{operationId}}Request {
+        {{#requiredParams}}
+        private final {{{dataType}}} {{paramName}};
+        {{/requiredParams}}
+        {{#optionalParams}}
+        private {{{dataType}}} {{paramName}};
+        {{/optionalParams}}
+
+        private API{{operationId}}Request({{#requiredParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/requiredParams}}) {
+            {{#requiredParams}}
+            this.{{paramName}} = {{paramName}};
+            {{/requiredParams}}
+        }
+
+        {{#optionalParams}}
+        /**
+         * Set {{paramName}}
+         * @param {{paramName}} {{description}} (optional{{^isContainer}}{{#defaultValue}}, default to {{.}}{{/defaultValue}}{{/isContainer}})
+         * @return API{{operationId}}Request
+         */
+        public API{{operationId}}Request {{paramName}}({{{dataType}}} {{paramName}}) {
+            this.{{paramName}} = {{paramName}};
+            return this;
+        }
+
+        {{/optionalParams}}
+        /**
+         * Build call for {{operationId}}
+         * @param _callback ApiCallback API callback
+         * @return Call to execute
+         * @throws ApiException If fail to serialize the request body object
+         {{#responses.0}}
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            {{#responses}}
+            <tr><td> {{code}} </td><td> {{message}} </td><td> {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} </td></tr>
+            {{/responses}}
+         </table>
+         {{/responses.0}}
+         {{#isDeprecated}}
+         * @deprecated
+         {{/isDeprecated}}
+         */
+        {{#isDeprecated}}
+        @Deprecated
+        {{/isDeprecated}}
+        public okhttp3.Call buildCall(final ApiCallback _callback) throws ApiException {
+            return {{operationId}}Call({{#allParams}}{{paramName}}, {{/allParams}}_callback);
+        }
+
+        /**
+         * Execute {{operationId}} request{{#returnType}}
+         * @return {{.}}{{/returnType}}
+         * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+         {{#responses.0}}
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            {{#responses}}
+            <tr><td> {{code}} </td><td> {{message}} </td><td> {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} </td></tr>
+            {{/responses}}
+         </table>
+         {{/responses.0}}
+         {{#isDeprecated}}
+         * @deprecated
+         {{/isDeprecated}}
+         */
+        {{#isDeprecated}}
+        @Deprecated
+        {{/isDeprecated}}
+        {{^vendorExtensions.x-streaming}}
+        public {{{returnType}}}{{^returnType}}void{{/returnType}} execute() throws ApiException {
+            {{#returnType}}ApiResponse<{{{.}}}> localVarResp = {{/returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});{{#returnType}}
+            return localVarResp.getData();{{/returnType}}
+        }
+        {{/vendorExtensions.x-streaming}}
+        {{#vendorExtensions.x-streaming}}
+        public InputStream execute() throws ApiException {
+            return {{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
+        }
+        {{/vendorExtensions.x-streaming}}
+
+        /**
+         * Execute {{operationId}} request with HTTP info returned
+         * @return ApiResponse&lt;{{returnType}}{{^returnType}}Void{{/returnType}}&gt;
+         * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+         {{#responses.0}}
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            {{#responses}}
+            <tr><td> {{code}} </td><td> {{message}} </td><td> {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} </td></tr>
+            {{/responses}}
+         </table>
+         {{/responses.0}}
+         {{#isDeprecated}}
+         * @deprecated
+         {{/isDeprecated}}
+         */
+        {{#isDeprecated}}
+        @Deprecated
+        {{/isDeprecated}}
+        {{^vendorExtensions.x-streaming}}
+        public ApiResponse<{{{returnType}}}{{^returnType}}Void{{/returnType}}> executeWithHttpInfo() throws ApiException {
+            return {{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
+        }
+        {{/vendorExtensions.x-streaming}}
+        {{#vendorExtensions.x-streaming}}
+        public InputStream executeWithHttpInfo() throws ApiException {
+            return {{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
+        }
+        {{/vendorExtensions.x-streaming}}
+
+        /**
+         * Execute {{operationId}} request (asynchronously)
+         * @param _callback The callback to be executed when the API call finishes
+         * @return The request call
+         * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+         {{#responses.0}}
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            {{#responses}}
+            <tr><td> {{code}} </td><td> {{message}} </td><td> {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} </td></tr>
+            {{/responses}}
+         </table>
+         {{/responses.0}}
+         {{#isDeprecated}}
+         * @deprecated
+         {{/isDeprecated}}
+         */
+        {{#isDeprecated}}
+        @Deprecated
+        {{/isDeprecated}}
+        public okhttp3.Call executeAsync(final ApiCallback<{{{returnType}}}{{^returnType}}Void{{/returnType}}> _callback) throws ApiException {
+            return {{operationId}}Async({{#allParams}}{{paramName}}, {{/allParams}}_callback);
+        }
+    }
+
+    /**
+     * {{summary}}
+     * {{notes}}{{#requiredParams}}
+     * @param {{paramName}} {{description}} (required){{/requiredParams}}
+     * @return API{{operationId}}Request
+     {{#responses.0}}
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        {{#responses}}
+        <tr><td> {{code}} </td><td> {{message}} </td><td> {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} </td></tr>
+        {{/responses}}
+     </table>
+     {{/responses.0}}
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
+        {{#externalDocs}}
+     * {{description}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
+        {{/externalDocs}}
+     */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
+    public API{{operationId}}Request {{operationId}}({{#requiredParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/requiredParams}}) {
+        return new API{{operationId}}Request({{#requiredParams}}{{paramName}}{{^-last}}, {{/-last}}{{/requiredParams}});
+    }
+    {{/vendorExtensions.x-group-parameters}}
+    {{/operation}}
+}
+{{/operations}}

--- a/generators/java/okhttp-gson/templates/libraries/okhttp-gson/api.mustache
+++ b/generators/java/okhttp-gson/templates/libraries/okhttp-gson/api.mustache
@@ -13,7 +13,6 @@ import {{invokerPackage}}.Configuration;
 import {{invokerPackage}}.Pair;
 import {{invokerPackage}}.ProgressRequestBody;
 import {{invokerPackage}}.ProgressResponseBody;
-import {{invokerPackage}}.FileTransfer;{{! Added import }}
 {{#performBeanValidation}}
 import {{invokerPackage}}.BeanValidationException;
 {{/performBeanValidation}}

--- a/generators/java/okhttp-gson/templates/libraries/okhttp-gson/api.mustache
+++ b/generators/java/okhttp-gson/templates/libraries/okhttp-gson/api.mustache
@@ -13,6 +13,7 @@ import {{invokerPackage}}.Configuration;
 import {{invokerPackage}}.Pair;
 import {{invokerPackage}}.ProgressRequestBody;
 import {{invokerPackage}}.ProgressResponseBody;
+import {{invokerPackage}}.FileTransfer;{{! Added import }}
 {{#performBeanValidation}}
 import {{invokerPackage}}.BeanValidationException;
 {{/performBeanValidation}}

--- a/generators/java/okhttp-gson/templates/libraries/okhttp-gson/oneof_model.mustache
+++ b/generators/java/okhttp-gson/templates/libraries/okhttp-gson/oneof_model.mustache
@@ -339,8 +339,6 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
      * @return The actual instance of `{{{dataType}}}`
      * @throws ClassCastException if the instance is not `{{{dataType}}}`
      */
-    {{! Suppress unchecked cast warning }}
-    @SuppressWarnings("unchecked")
     public {{{dataType}}} get{{#isArray}}{{#sanitizeGeneric}}{{{dataType}}}{{/sanitizeGeneric}}{{/isArray}}{{^isArray}}{{{dataType}}}{{/isArray}}() throws ClassCastException {
         return ({{{dataType}}})super.getActualInstance();
     }
@@ -453,41 +451,32 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
 
     {{! Added block of code based on com/onfido/model/ReportShared.java - BEGIN }}
 
-    /**
-     * Give access to shared properties. Read-only.
-     * @return ReportShared object with common fields
-     **/
+  /**
+  * Give access to shared properties. Read-only.
+  * @return ReportShared object with common fields
+  **/
 
-    public ReportShared getReportShared() {
-        return reportShared;
-    }
+  public ReportShared getReportShared() {
+      return reportShared;
+  }
 
-    /**
-     * Give access to shared properties. Read-only.
-     * @return id
-     **/
+  /**
+  * Give access to shared properties. Read-only.
+  * @return id
+  **/
 
-    public UUID getId() {
-        return reportShared.getId();
-    }
+  public UUID getId() {
+      return reportShared.getId();
+  }
 
-    /**
-     * Get name
-     * @return name
-     **/
+  /**
+  * Get name
+  * @return name
+  **/
 
-    public ReportName getName() {
-        return reportShared.getName();
-    }
-
-    /**
-     * Get status
-     * @return status
-     **/
-
-    public ReportStatus getStatus() {
-        return reportShared.getStatus();
-    }
+  public ReportName getName() {
+      return reportShared.getName();
+  }
 
   {{! Added block of code based on com/onfido/model/ReportShared.java - END }}
 }

--- a/generators/java/okhttp-gson/templates/libraries/okhttp-gson/oneof_model.mustache
+++ b/generators/java/okhttp-gson/templates/libraries/okhttp-gson/oneof_model.mustache
@@ -339,6 +339,8 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
      * @return The actual instance of `{{{dataType}}}`
      * @throws ClassCastException if the instance is not `{{{dataType}}}`
      */
+    {{! Suppress unchecked cast warning }}
+    @SuppressWarnings("unchecked")
     public {{{dataType}}} get{{#isArray}}{{#sanitizeGeneric}}{{{dataType}}}{{/sanitizeGeneric}}{{/isArray}}{{^isArray}}{{{dataType}}}{{/isArray}}() throws ClassCastException {
         return ({{{dataType}}})super.getActualInstance();
     }
@@ -451,32 +453,41 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
 
     {{! Added block of code based on com/onfido/model/ReportShared.java - BEGIN }}
 
-  /**
-  * Give access to shared properties. Read-only.
-  * @return ReportShared object with common fields
-  **/
+    /**
+     * Give access to shared properties. Read-only.
+     * @return ReportShared object with common fields
+     **/
 
-  public ReportShared getReportShared() {
-      return reportShared;
-  }
+    public ReportShared getReportShared() {
+        return reportShared;
+    }
 
-  /**
-  * Give access to shared properties. Read-only.
-  * @return id
-  **/
+    /**
+     * Give access to shared properties. Read-only.
+     * @return id
+     **/
 
-  public UUID getId() {
-      return reportShared.getId();
-  }
+    public UUID getId() {
+        return reportShared.getId();
+    }
 
-  /**
-  * Get name
-  * @return name
-  **/
+    /**
+     * Get name
+     * @return name
+     **/
 
-  public ReportName getName() {
-      return reportShared.getName();
-  }
+    public ReportName getName() {
+        return reportShared.getName();
+    }
+
+    /**
+     * Get status
+     * @return status
+     **/
+
+    public ReportStatus getStatus() {
+        return reportShared.getStatus();
+    }
 
   {{! Added block of code based on com/onfido/model/ReportShared.java - END }}
 }


### PR DESCRIPTION
To allow in-memory file download, a new object `FileTransfer` has created for Java Client library.
It includes some changes to templates to integrate such object, and a few fix and improvement.
This new `FileTransfer` object allows uploading/downloading a file from/to disk or from memory.
It also adds `getStatus()` method to generic Report object for Java.

Preview of changes we're going to have in client library is below:
https://github.com/onfido/onfido-java/compare/in-memory-file-transfer