### PR TITLE
[CAT-1120] Improve facial similarity fully auto report and fix Postman collection

### DIFF
--- a/schemas/reports/facial_similarity_motion_properties.yaml
+++ b/schemas/reports/facial_similarity_motion_properties.yaml
@@ -1,0 +1,9 @@
+type: object
+properties:
+  score:
+    type: number
+    format: float
+    description: |
+      A floating point number between 0 and 1. The closer the score is to 0, the more likely
+      it is to be a spoof (i.e. videos of digital screens, masks or print-outs).
+      Conversely, the closer it is to 1, the less likely it is to be a spoof.

--- a/schemas/reports/facial_similarity_motion_report.yaml
+++ b/schemas/reports/facial_similarity_motion_report.yaml
@@ -4,3 +4,5 @@ allOf:
     properties:
       breakdown:
         $ref: facial_similarity_motion_breakdown.yaml
+      properties:
+        $ref: facial_similarity_motion_properties.yaml

--- a/schemas/reports/facial_similarity_photo_fully_auto_properties.yaml
+++ b/schemas/reports/facial_similarity_photo_fully_auto_properties.yaml
@@ -1,0 +1,9 @@
+type: object
+properties:
+  score:
+    type: number
+    format: float
+    description: |
+      A floating point number between 0 and 1. The closer the score is to 0, the more likely
+      it is to be a spoof (i.e. photos of printed photos, or photos of digital screens).
+      Conversely, the closer it is to 1, the less likely it is to be a spoof.

--- a/schemas/reports/facial_similarity_photo_fully_auto_report.yaml
+++ b/schemas/reports/facial_similarity_photo_fully_auto_report.yaml
@@ -4,3 +4,5 @@ allOf:
     properties:
       breakdown:
         $ref: facial_similarity_photo_fully_auto_breakdown.yaml
+      properties:
+        $ref: facial_similarity_photo_fully_auto_properties.yaml

--- a/schemas/reports/facial_similarity_photo_properties.yaml
+++ b/schemas/reports/facial_similarity_photo_properties.yaml
@@ -1,0 +1,9 @@
+type: object
+properties:
+  score:
+    type: number
+    format: float
+    description: |
+      A floating point number between 0 and 1. The closer the score is to 0, the more likely
+      it is to be a spoof (i.e. photos of printed photos, or photos of digital screens).
+      Conversely, the closer it is to 1, the less likely it is to be a spoof.

--- a/schemas/reports/facial_similarity_photo_report.yaml
+++ b/schemas/reports/facial_similarity_photo_report.yaml
@@ -4,3 +4,5 @@ allOf:
     properties:
       breakdown:
         $ref: facial_similarity_photo_breakdown.yaml
+      properties:
+        $ref: facial_similarity_photo_properties.yaml

--- a/schemas/reports/facial_similarity_video_properties.yaml
+++ b/schemas/reports/facial_similarity_video_properties.yaml
@@ -1,0 +1,9 @@
+type: object
+properties:
+  score:
+    type: number
+    format: float
+    description: |
+      A floating point number between 0 and 1. The closer the score is to 0, the more likely
+      it is to be a spoof (i.e. videos of digital screens, masks or print-outs).
+      Conversely, the closer it is to 1, the less likely it is to be a spoof.

--- a/schemas/reports/facial_similarity_video_report.yaml
+++ b/schemas/reports/facial_similarity_video_report.yaml
@@ -4,3 +4,5 @@ allOf:
     properties:
       breakdown:
         $ref: facial_similarity_video_breakdown.yaml
+      properties:
+        $ref: facial_similarity_video_properties.yaml


### PR DESCRIPTION
- Add missing `properties` field in `facial_similarity_*` reports
- Patch generated Postman collection to properly generate upload endpoints (while waiting for https://github.com/postmanlabs/openapi-to-postman/issues/795's resolution)