### PR TITLE
[CAT-1120] Fix tags retrieval in CI + python README.md

### DIFF
--- a/.github/workflows/update-specs-and-client-libraries.yaml
+++ b/.github/workflows/update-specs-and-client-libraries.yaml
@@ -93,7 +93,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 10
-      - name: Retrieve information about last commit not authored by GitHub Actions Bot
+          fetch-tags: true
+      - name: Retrieve information about last commit not authored by GitHub Actions Bot and release (if any)
         id: retriever
         run: |
           git config --global --add safe.directory $(pwd)
@@ -231,7 +232,7 @@ jobs:
         run: |
           chmod +x shell/sync-lib.sh
           shell/sync-lib.sh $(echo ${{ matrix.git_repo_id }} | sed 's/^onfido-//') ${{ matrix.generator }}
-      - name: Update CHANGELOG and lint .md files as needed
+      - name: Update release file and lint .md files as needed
         if: ${{ matrix.update }}
         run: |
           TMP_FILE=$(mktemp)

--- a/generators/python/urllib3/config.yaml
+++ b/generators/python/urllib3/config.yaml
@@ -1,5 +1,6 @@
 gitRepoId: onfido-python
-packageName: onfido
+distributionPackageName: onfido-python
+packageName: onfido # i.e. import package name
 packageVersion: ${CLIENT_LIBRARY_VERSION}
 useOneOfDiscriminatorLookup: true
 httpUserAgent: onfido-python/${CLIENT_LIBRARY_VERSION}

--- a/generators/python/urllib3/templates/README.mustache
+++ b/generators/python/urllib3/templates/README.mustache
@@ -19,7 +19,7 @@ Python {{{generatorLanguageVersion}}}
 If the python package is hosted on a repository, you can install directly using:
 
 ```sh
-pip install {{{packageName}}}
+pip install {{{distributionPackageName}}}
 ```
 
 Then import the package:
@@ -31,7 +31,7 @@ import {{{packageName}}}
 #### Poetry
 
 ```sh
-poetry add {{{packageName}}}
+poetry add {{{distributionPackageName}}}
 ```
 
 Then import the package:

--- a/generators/python/urllib3/templates/pyproject.mustache
+++ b/generators/python/urllib3/templates/pyproject.mustache
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "{{{packageName}}}-python"                                 {{! package name updated with -python suffix }}
+name = "{{{distributionPackageName}}}"                            {{! package name updated with -python suffix }}
 version = "{{{packageVersion}}}"
 description = "Python library for the Onfido API"                 {{! customized description }}
 authors = ["OpenAPI Generator Community <{{infoEmail}}{{^infoEmail}}team@openapitools.org{{/infoEmail}}>"] {{! removed infoName field since wronlgy set }}


### PR DESCRIPTION
Spec tag wasn't correctly retrieved in CI (e.g. [here](https://github.com/onfido/onfido-openapi-spec/actions/runs/9641340543/job/26586831612)):

```
SOURCE_VERSION=
SOURCE_VERSION=${SOURCE_VERSION:-}
```

This was due to the fact actions/checkout@v4 plugin wasn't fetching tags.
Taking the opportunity for fixing also the package distribution name in python library's README.