### PR TITLE
Add/update badges in generated README.md files

### DIFF
--- a/generators/java/okhttp-gson/templates/README.mustache
+++ b/generators/java/okhttp-gson/templates/README.mustache
@@ -8,6 +8,8 @@ This library is only for use on the backend, as it uses Onfido API tokens which 
 
 This version uses Onfido API {{ apiVersion }}. Refer to our [API versioning guide](https://developers.onfido.com/guide/api-versioning-policy#client-libraries) for details of which client library versions use which versions of the API.
 
+![Build Status](https://github.com/{{{ gitUserId }}}/{{{ gitRepoId }}}/actions/workflows/maven.yml/badge.svg)
+
 ## Installation & Usage
 
 ### Requirements

--- a/generators/php/templates/README.mustache
+++ b/generators/php/templates/README.mustache
@@ -13,6 +13,9 @@ This version uses Onfido API {{ apiVersion }}. Refer to our [API versioning guid
 PHP 7.4 and later.
 Should also work with PHP 8.0.
 
+[![Latest release](https://badge.fury.io/ph/{{{gitUserId}}}%2F{{{gitRepoId}}}.svg)](https://badge.fury.io/ph/{{{gitUserId}}}%2F{{{gitRepoId}}})
+![Build Status](https://github.com/{{{ gitUserId }}}/{{{ gitRepoId }}}/actions/workflows/php.yml/badge.svg)
+
 ### Installation
 
 #### Composer

--- a/generators/python/urllib3/templates/README.mustache
+++ b/generators/python/urllib3/templates/README.mustache
@@ -6,6 +6,9 @@ Documentation can be found at <{{ documentationUrl }}>.
 
 This version uses Onfido API {{ apiVersion }}. Refer to our [API versioning guide](https://developers.onfido.com/guide/api-versioning-policy#client-libraries) for details of which client library versions use which versions of the API.
 
+[![PyPI version](https://badge.fury.io/py/{{{distributionPackageName}}}.svg)](https://badge.fury.io/py/{{{distributionPackageName}}})
+![Build Status](https://github.com/{{{gitUserId}}}/{{{gitRepoId}}}/actions/workflows/python.yml/badge.svg)
+
 ## Installation & Usage
 
 ### Requirements

--- a/generators/ruby/faraday/templates/README.mustache
+++ b/generators/ruby/faraday/templates/README.mustache
@@ -6,8 +6,8 @@ Documentation can be found at <{{ documentationUrl }}>.
 
 This version uses Onfido API {{ apiVersion }}. Refer to our [API versioning guide](https://developers.onfido.com/guide/api-versioning-policy#client-libraries) for details of which client library versions use which versions of the API.
 
-[![Gem Version](https://badge.fury.io/rb/onfido.svg)](http://badge.fury.io/rb/onfido)
-[![Build Status](https://travis-ci.org/onfido/onfido-ruby.svg?branch=master)](https://travis-ci.org/onfido/onfido-ruby)
+[![Gem Version](https://badge.fury.io/rb/{{{gemName}}}.svg)](https://badge.fury.io/rb/{{{gemName}}})
+![Build Status](https://github.com/onfido/{{{gitRepoId}}}/actions/workflows/ruby.yml/badge.svg)
 
 ## Installation & Usage
 

--- a/generators/typescript-axios/templates/README.mustache
+++ b/generators/typescript-axios/templates/README.mustache
@@ -8,6 +8,9 @@ This library is only for use on the backend, as it uses Onfido API tokens which 
 
 This version uses Onfido API {{ apiVersion }}. Refer to our [API versioning guide](https://developers.onfido.com/guide/api-versioning-policy#client-libraries) for details of which client library versions use which versions of the API.
 
+[![npm version](https://badge.fury.io/js/@onfido%2Fapi.svg)](https://badge.fury.io/js/@onfido%2Fapi)
+![Build Status](https://github.com/{{{ gitUserId }}}/{{{ gitRepoId }}}/actions/workflows/node.yml/badge.svg)
+
 ## Installation & Usage
 
 ### Installation


### PR DESCRIPTION
Just spotted out that in [Ruby README.md](https://github.com/onfido/onfido-ruby/blob/master/README.md) we've a broken link (pointing to [trevis CI](https://app.travis-ci.com/onfido/onfido-ruby)).

Taking the opportunity to add fury.io (when available) and github build status badge in all languages README.md files.