### PR TITLE
[CAT-1297] Webhook Event: remove uuid format from object.id

### DIFF
--- a/schemas/webhooks/webhook_event.yaml
+++ b/schemas/webhooks/webhook_event.yaml
@@ -25,7 +25,6 @@ properties:
         properties:
           id:
             type: string
-            format: uuid
             description: The unique identifier of the resource.
           status:
             type: string


### PR DESCRIPTION
As reported `id` property (inside `object`) is not an uuid, therefore uuid format needs to be removed.