### PR TITLE
add jpeg file type for documents

### DIFF
--- a/schemas/documents/definitions.yaml
+++ b/schemas/documents/definitions.yaml
@@ -5,6 +5,7 @@ document_shared:
       type: string
       enum:
         - jpg
+        - jpeg
         - png
         - pdf
       description: The file type of the uploaded file


### PR DESCRIPTION
Hi,

as I can't open issues here, I need to open a PR :-) 
(this PR shouldn't be merged like this of course)

When requesting documents that the WebSDK uploaded, they have a file_type of "jpeg". The OpenAPI spec however only lists "jpg" as allowed value.
Somehow this should be adapted as your API is not working according to the specification.

Example response from the api:
```
GET https://api.eu.onfido.com/v3.6/documents/2e503b6a-99c6-4829-802b-9e43903b7c22
{
    "applicant_id": "ce61a2a3-4190-43d2-b634-e7bdabad760b",
    "id": "2e503b6a-99c6-4829-802b-9e43903b7c22",
    "file_name": "document_back.jpeg",
    "file_type": "jpeg",
    "file_size": 2610325,
    [...]
}
```

Thanks, Christoph
