### PR TITLE
Use document-type enum for document upload

### DIFF
--- a/schemas/document_types/document_types.yaml
+++ b/schemas/document_types/document_types.yaml
@@ -24,4 +24,9 @@ enum:
   - professional_qualification_card
   - consular_id
   - international_driving_licence
+  - home_office_letter
+  - birth_certificate
+  - vehicle_registration_certificate
+  - form_for_affixing_the_visa
+  - identification_number_document
 type: string

--- a/schemas/documents/definitions.yaml
+++ b/schemas/documents/definitions.yaml
@@ -12,6 +12,8 @@ document_shared:
     type:
       type: string
       description: The type of document
+      allOf:
+        - $ref: ../document_types/document_types.yaml
     side:
       type: string
       enum:


### PR DESCRIPTION
Use document-types enum for `upload_document` endpoint.

Add document type below to the enum:
```yaml

  - home_office_letter
  - birth_certificate
  - vehicle_registration_certificate
  - form_for_affixing_the_visa
  - identification_number_document
```

NB: this change will create breaking change in most of the libraries, a major update will be necessary.