### PR TITLE
Fix OpenAPI pattern definitions to improve Postman experience

### DIFF
--- a/schemas/address/definitions.yaml
+++ b/schemas/address/definitions.yaml
@@ -36,15 +36,15 @@ address_shared:
     line1:
       type: string
       nullable: true
-      pattern: "/^[^!$%^*=<>]*$/"
+      pattern: ^[^!$%^*=<>]*$
       description: Line 1 of the applicant's address
     line2:
       type: string
       nullable: true
-      pattern: "/^[^!$%^*=<>]*$/"
+      pattern: ^[^!$%^*=<>]*$
       description: Line 2 of the applicant's address
     line3:
       type: string
       nullable: true
-      pattern: "/^[^!$%^*=<>]*$/"
+      pattern: ^[^!$%^*=<>]*$
       description: Line 3 of the applicant's address

--- a/schemas/applicants/definitions.yaml
+++ b/schemas/applicants/definitions.yaml
@@ -76,10 +76,10 @@ applicant_update:
 
 applicant_first_name:
   type: string
-  pattern: '/^[^!#$%*=<>;{}"]*$/'
+  pattern: ^[^!#$%*=<>;{}"]*$
   description: The applicant's first name
 
 applicant_last_name:
   type: string
-  pattern: '/^[^!#$%*=<>;{}"]*$/'
+  pattern: ^[^!#$%*=<>;{}"]*$
   description: The applicant's surname

--- a/schemas/extractions/extraction.yaml
+++ b/schemas/extractions/extraction.yaml
@@ -74,7 +74,7 @@ properties:
         description: Date of expiry in YYYY-MM-DD format.
       nationality:
         type: string
-        pattern: "/^[A-Z]{3}$/"
+        pattern: ^[A-Z]{3}$
         description: Nationality in 3-letter ISO code.
       mrz_line_1:
         type: string

--- a/schemas/us_driving_licence/definitions.yaml
+++ b/schemas/us_driving_licence/definitions.yaml
@@ -11,7 +11,7 @@ us_driving_licence_shared:
     issue_state:
       type: string
       description: Two letter code of issuing state (state-issued driving licenses only)
-      pattern: "/^[A-Z]{2}$/"
+      pattern: ^[A-Z]{2}$
     address_line_1:
       type: string
       description: Line 1 of the address


### PR DESCRIPTION
Fix pattern (regex) definitions for a few fields to make example being shown in postman collection.