### PR TITLE
Including `faraday-follow_redirects` as a runtime dependency in ruby

### DIFF
--- a/generators/ruby/faraday/templates/gemspec.mustache
+++ b/generators/ruby/faraday/templates/gemspec.mustache
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   {{#isFaraday}}
   s.add_runtime_dependency 'faraday', '>= 1.0.1', '< 3.0'
-  s.add_runtime_dependency 'faraday-follow_redirects', '~> 0.3.0'
+  s.add_runtime_dependency 'faraday-follow_redirects', '~> 0.3.0'   {{! added dependency }}
   s.add_runtime_dependency 'faraday-multipart'
   s.add_runtime_dependency 'marcel'
   {{/isFaraday}}

--- a/generators/ruby/faraday/templates/gemspec.mustache
+++ b/generators/ruby/faraday/templates/gemspec.mustache
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
 
   {{#isFaraday}}
   s.add_runtime_dependency 'faraday', '>= 1.0.1', '< 3.0'
+  s.add_runtime_dependency 'faraday-follow_redirects', '~> 0.3.0'
   s.add_runtime_dependency 'faraday-multipart'
   s.add_runtime_dependency 'marcel'
   {{/isFaraday}}


### PR DESCRIPTION
the current version of the `onfido-ruby` repository requires `faraday-follow-redirects`, but the gemspec generated by this project doesn't include it.

This causes our Rails project to fail when loading onfido configuration due to [this line](https://github.com/onfido/onfido-ruby/blob/b49ddfe50718a84fb3b054312bc31042d31e4ec6/lib/onfido/configuration.rb#L13). 

I expect this would be a problem for most anyone using the latest version of `onfido-ruby`.
