### PR TITLE
fix: resolve `setRegion` method argument in PHP

### DIFF
--- a/generators/php/templates/Configuration.mustache
+++ b/generators/php/templates/Configuration.mustache
@@ -127,7 +127,7 @@ class Configuration
     /**
      * Sets Region
      *
-     * @param string $region           Region to target
+     * @param Region $region           Region to target
      *
      * @return $this
      */


### PR DESCRIPTION
The `setRegion()` method in PHP expects an instance of the `Region` enum, however the PHPDoc comment states that it requires a `string`, this means that static analysis and IDEs complain when calling it, but it works correctly. However, if you pass a `string` it fails because the `->name` property does not exist.