### PR TITLE
Fix examples in templated README in typescript

### DIFF
--- a/generators/typescript-axios/templates/README.mustache
+++ b/generators/typescript-axios/templates/README.mustache
@@ -132,15 +132,15 @@ onfido
 
 ### File download
 
-File downloads, for example `onfido.downloadDocument(documentId, {responseType: 'arraybuffer'})`, will return an instance of a specific object for this endpoint.
+File downloads, for example `onfido.downloadDocument(documentId)`, will return an instance of a `FileTransfer` object.
 
-These objects will have a content type, e.g. `image/png`.
+This object will have a content type, e.g. `image/png`.
 
 ```js
 download.headers["content-type"];
 ```
 
-Call `slice()` to get a `Blob` of the download:
+Call `slice()` to get a `Buffer` of the download:
 
 ```js
 const blob = download.data.slice();
@@ -148,7 +148,7 @@ const blob = download.data.slice();
 
 ### File upload
 
-File upload should use the provided FileTransfer class, e.g.:
+File upload should make use of the provided `FileTransfer` class, e.g.:
 
 ```js
 onfido.uploadDocument(
@@ -158,7 +158,7 @@ onfido.uploadDocument(
 );
 ```
 
-FileTransfer object can also be created from an existing file, e.g. `new FileTransfer("path/to/passport.png")`.
+`FileTransfer` object can also be created from an existing file, e.g. `new FileTransfer("path/to/passport.png")`.
 
 ### Webhook event verification
 

--- a/generators/typescript-axios/templates/README.mustache
+++ b/generators/typescript-axios/templates/README.mustache
@@ -148,15 +148,17 @@ const blob = download.data.slice();
 
 ### File upload
 
-For some common types of streams, like instances of `fs.ReadStream`, you can provide the stream directly:
+File upload should use the provided FileTransfer class, e.g.:
 
 ```js
 onfido.uploadDocument(
   "passport",
   "<APPLICANT_ID>",
-  fs.createReadStream("path/to/passport.png"),
+  new FileTransfer(Buffer.from(document.buffer), document.filename),
 );
 ```
+
+FileTransfer object can also be created from an existing file, e.g. `new FileTransfer("path/to/passport.png")`.
 
 ### Webhook event verification
 


### PR DESCRIPTION
A few improvement to typescript README template, including change from https://github.com/onfido/onfido-node/pull/141.