### PR TITLE
Update workflow to include hidden file in archived artifacts

### DIFF
--- a/.github/workflows/update-specs-and-client-libraries.yaml
+++ b/.github/workflows/update-specs-and-client-libraries.yaml
@@ -170,6 +170,7 @@ jobs:
       image: ${{ matrix.image }}
     needs: generate_specs_and_libraries
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - generator: java/okhttp-gson
@@ -200,6 +201,7 @@ jobs:
     environment: generation
     steps:
       - name: Install pre-requisites
+        if: ${{ matrix.update }}
         run: |
           if [ "$(command -v rsync)" = "" ];
           then

--- a/.github/workflows/update-specs-and-client-libraries.yaml
+++ b/.github/workflows/update-specs-and-client-libraries.yaml
@@ -113,6 +113,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-${{ github.workflow }}-${{ github.run_id }}-${{ github.run_number }}
+          include-hidden-files: true
           path: |
             shell/sync-lib.sh
             generated/artifacts


### PR DESCRIPTION
We've realised in commit https://github.com/onfido/onfido-node/pull/143/commits/52aad0a7a94e0af3616cddfc91c50a40298886a2 that some hidden files were surpresly missing.

This fix is to avoid bad consequences from breaking change to `actions/upload-artifact` announced below:
https://github.com/actions/upload-artifact/issues/602