### PR TITLE
SDK Token: Remove UUID format from application_id.

### DIFF
--- a/schemas/sdk_token/definitions.yaml
+++ b/schemas/sdk_token/definitions.yaml
@@ -12,7 +12,6 @@ sdk_token_request:
       description: The referrer URL pattern
     application_id:
       type: string
-      format: uuid
       description: The application ID (iOS or Android)
     cross_device_url:
       type: string


### PR DESCRIPTION
Looking at the mobile sdk docs [here](https://documentation.onfido.com/sdk/react-native/9.0.0/#3-configuring-sdk-with-tokens)

The application_id field of sdk_token does not seem to be a UUID:

> The application_id is the "Application ID" or "Bundle ID" that was already set up during development.

> For iOS this is usually in the form of com.your-company.app-name.
> To get this value manually, open xcode ios/YourProjectName, click on the project root, click the General tab, under Targets click your project name, and check the Bundle Identifier field.
> To get this value programmatically in native iOS code, see [Stack Overflow Page](https://stackoverflow.com/questions/8873203/how-to-get-bundle-id).

> For Android this is usually in the form of com.example.yourapp.
> To get this file manually, you can find it in your app's build.config. For example, in android/app/build.gradle, it is the value of applicationId.
> To get this value programmatically in native Java code, see [Stack Overflow Page](https://stackoverflow.com/questions/14705874/bundle-id-in-android).