### PR TITLE
[CAT-1376] Fix records item type in watchlist reports properties

### DIFF
--- a/schemas/reports/watchlist_aml_properties.yaml
+++ b/schemas/reports/watchlist_aml_properties.yaml
@@ -4,4 +4,4 @@ properties:
     description: Returns any matches including, but not limited to, name and date of birth of match, aliases and associates, and relevant events and sources.
     type: array
     items:
-      type: string
+      type: object

--- a/schemas/reports/watchlist_enhanced_properties.yaml
+++ b/schemas/reports/watchlist_enhanced_properties.yaml
@@ -4,4 +4,4 @@ properties:
     description: Returns any matches including, but not limited to, name and date of birth of match, aliases and associates, and relevant events and sources.
     type: array
     items:
-      type: string
+      type: object

--- a/schemas/reports/watchlist_standard_properties.yaml
+++ b/schemas/reports/watchlist_standard_properties.yaml
@@ -4,4 +4,4 @@ properties:
     description: Returns any matches including, but not limited to, name and date of birth of match, aliases and associates, and relevant events and sources.
     type: array
     items:
-      type: string
+      type: object


### PR DESCRIPTION
Correct the type of `records`  in reports below from string to object:
-  watchlist_aml
- watchlist_enhanced
- watchlist_standard
- watchlist_peps_only
- watchlist_sanctions_only
