### PR TITLE
[CAT-1376] Add record item object definition for watchlist enhanced properties field

### DIFF
--- a/schemas/reports/watchlist_aml_properties.yaml
+++ b/schemas/reports/watchlist_aml_properties.yaml
@@ -4,4 +4,4 @@ properties:
     description: Returns any matches including, but not limited to, name and date of birth of match, aliases and associates, and relevant events and sources.
     type: array
     items:
-      type: object
+      type: string

--- a/schemas/reports/watchlist_enhanced_properties.yaml
+++ b/schemas/reports/watchlist_enhanced_properties.yaml
@@ -71,13 +71,15 @@ properties:
                 type: string
               event_date:
                 type: string
+                format: date
               event_description:
                 type: string
-              sources:
+              source:
                 type: object
                 properties:
                   source_date:
                     type: string
+                    format: date
                   source_format:
                     type: string
                   source_name:
@@ -86,12 +88,15 @@ properties:
                 type: string
         full_name:
           type: string
+          description: The name on file
         position:
           type: array
+          description: The role, country and date of each position.
           items:
             type: string
         source:
           type: array
+          description: Details about where the information was obtained.
           items:
             type: object
             properties:

--- a/schemas/reports/watchlist_enhanced_properties.yaml
+++ b/schemas/reports/watchlist_enhanced_properties.yaml
@@ -84,6 +84,8 @@ properties:
                     type: string
                   source_name:
                     type: string
+                  source_url:
+                    type: string
               sub_category:
                 type: string
         full_name:
@@ -105,4 +107,6 @@ properties:
               source_name:
                 type: string
               source_url:
+                type: string
+              source_format:
                 type: string

--- a/schemas/reports/watchlist_enhanced_properties.yaml
+++ b/schemas/reports/watchlist_enhanced_properties.yaml
@@ -84,12 +84,12 @@ properties:
                     type: string
               sub_category:
                 type: string
-          full_name:
+        full_name:
+          type: string
+        position:
+          type: array
+          items:
             type: string
-          position:
-            type: array
-            items:
-              type: string
         source:
           type: array
           items:

--- a/schemas/reports/watchlist_enhanced_properties.yaml
+++ b/schemas/reports/watchlist_enhanced_properties.yaml
@@ -16,6 +16,8 @@ properties:
                 type: string
               country:
                 type: string
+                allOf:
+                  - $ref: ../countries/country_codes.yaml
               postal_code:
                 type: string
               state_province:

--- a/schemas/reports/watchlist_enhanced_properties.yaml
+++ b/schemas/reports/watchlist_enhanced_properties.yaml
@@ -5,3 +5,99 @@ properties:
     type: array
     items:
       type: object
+      properties:
+        address:
+          type: array
+          description: All addresses on file.
+          items:
+            type: object
+            properties:
+              address_line1:
+                type: string
+              country:
+                type: string
+              postal_code:
+                type: string
+              state_province:
+                type: string
+              town:
+                type: string
+              locator_type:
+                type: string
+        alias:
+          type: array
+          description: Any names that the person is also known as.
+          items:
+            type: object
+            properties:
+              alias_name:
+                type: string
+              alias_type:
+                type: string
+        associate:
+          type: array
+          description: Any linked persons, for example family relatives or business partners.
+          items:
+            type: object
+            properties:
+              entity_name:
+                type: string
+              relationship_direction:
+                type: string
+              relationship_type:
+                type: string
+        attribute:
+          type: array
+          description: Information about the person, for example hair color or nationality.
+          items:
+            type: object
+            properties:
+              attribute_type:
+                type: string
+              attribute_value:
+                type: string
+        date_of_birth:
+          type: array
+          description: All the date of births on file.
+          items:
+            type: string
+        event:
+          type: array
+          description: Information about events that have occurred to the person, for example deportation or arrest.
+          items:
+            type: object
+            properties:
+              category:
+                type: string
+              event_date:
+                type: string
+              event_description:
+                type: string
+              sources:
+                type: object
+                properties:
+                  source_date:
+                    type: string
+                  source_format:
+                    type: string
+                  source_name:
+                    type: string
+              sub_category:
+                type: string
+          full_name:
+            type: string
+          position:
+            type: array
+            items:
+              type: string
+        source:
+          type: array
+          items:
+            type: object
+            properties:
+              source_headline:
+                type: string
+              source_name:
+                type: string
+              source_url:
+                type: string

--- a/schemas/reports/watchlist_standard_properties.yaml
+++ b/schemas/reports/watchlist_standard_properties.yaml
@@ -4,4 +4,4 @@ properties:
     description: Returns any matches including, but not limited to, name and date of birth of match, aliases and associates, and relevant events and sources.
     type: array
     items:
-      type: object
+      type: string


### PR DESCRIPTION
Reflecting in our OpenAPI specification what is in our public documentation:
https://documentation.onfido.com/api/latest/#records-1

It completes and partially revert changes (not released yet) from https://github.com/onfido/onfido-openapi-spec/pull/118.