### PR TITLE
Unpin vulnerable urllib3 version

### DIFF
--- a/generators/python/urllib3/templates/setup.mustache
+++ b/generators/python/urllib3/templates/setup.mustache
@@ -17,7 +17,7 @@ PYTHON_REQUIRES = ">=3.7"
 {{#apis}}
 {{#-last}}
 REQUIRES = [
-    "urllib3 >= 1.25.3, < 2.1.0",
+    "urllib3 >= 1.25.3",
     "python-dateutil",
 {{#asyncio}}
     "aiohttp >= 3.0.0",


### PR DESCRIPTION
## Context
The onfido-python generated library has been introducing a vulnerability in my codebase since June 17, as the urllib3 dependency for onfido-python is pinned at < 2.1.0. The vulnerability affects all 2x versions <=2.2.1. 

CVE: https://github.com/urllib3/urllib3/security/advisories/GHSA-34jh-p97f-mpxf. 

I looked through this codebase history and generated the python client lib locally. I don't think the pin to < 2.1.0 was necessary, or are there any breaking changes that affect the client lib generation.

## Changes
Remove the < 2.1.0 version pin for urllib3 in the python client generator. 