### PR TITLE
[CAT-1379] Fix check creation, remove some deprecated properties and deprecate others

### DIFF
--- a/schemas/checks/definitions.yaml
+++ b/schemas/checks/definitions.yaml
@@ -24,6 +24,8 @@ check_shared:
     redirect_uri:
       type: string
       description: For checks where `applicant_provides_data` is `true`, redirect to this URI when the applicant has submitted their data.
+    privacy_notices_read_consent_given:
+      type: boolean
 
 check_request:
   type: object
@@ -119,5 +121,3 @@ check_response:
     version:
       type: string
       example: 3.6
-    privacy_notices_read_consent_given:
-      type: boolean

--- a/schemas/reports/device_intelligence_breakdown.yaml
+++ b/schemas/reports/device_intelligence_breakdown.yaml
@@ -72,22 +72,6 @@ properties:
           fake_network_request:
             type: boolean
             description: Whether device is using stolen security tokens to send the network information.
-          true_os:
-            type: string
-            description: The true operating system of the device.
-            deprecated: true
-          os_anomaly:
-            type: string
-            description: The likelihood of an operating system anomaly between the true OS and the OS sent by the device.
-            deprecated: true
-          rooted:
-            type: boolean
-            description: Whether the device is rooted.
-            deprecated: true
-          remote_software:
-            type: boolean
-            description: Whether the device is controlled via remote software.
-            deprecated: true
           ip_reputation:
             type: string
             enum:
@@ -120,18 +104,6 @@ properties:
           address:
             type: string
             description: The IP address that uploaded the media.
-          vpn_detection:
-            type: string
-            description: The likelihood of the network connection being a VPN.
-            deprecated: true
-          proxy_detection:
-            type: string
-            description: The likelihood of the network connection being a Proxy.
-            deprecated: true
-          type:
-            type: string
-            description: The type of organization that owns this IP address.
-            deprecated: true
       geolocation:
         type: object
         properties:

--- a/schemas/reports/watchlist_aml_properties.yaml
+++ b/schemas/reports/watchlist_aml_properties.yaml
@@ -5,3 +5,4 @@ properties:
     type: array
     items:
       type: string
+    deprecated: true

--- a/schemas/reports/watchlist_standard_properties.yaml
+++ b/schemas/reports/watchlist_standard_properties.yaml
@@ -5,3 +5,4 @@ properties:
     type: array
     items:
       type: string
+    deprecated: true


### PR DESCRIPTION
Completing change in https://github.com/onfido/onfido-openapi-spec/pull/125, in which `privacy_notices_read_consent_given` has been defined only among response properties.

Taking the opportunity for removing a few fields which has been deprecated since a while and deprecating others.