### PR TITLE
[CAT-1306] Remove duplicated values from webhook event object status

### DIFF
--- a/schemas/webhooks/webhook_event.yaml
+++ b/schemas/webhooks/webhook_event.yaml
@@ -130,14 +130,14 @@ webhook_event_object_status:
     # ../reports/definitions.yaml#/report_status
     - awaiting_data
     - awaiting_approval
-    - cancelled
+    # - cancelled (already defined)
     - complete
     - withdrawn
     # ../checks/definitions.yaml#/check_status
     - in_progress
     - awaiting_applicant
-    - complete
-    - withdrawn
+    # - complete (already defined)
+    # - withdrawn (already defined)
     - paused
     - reopened
   description: The current state of the object, if available.


### PR DESCRIPTION
Removing duplicated enum as python library is [not happy about that](https://github.com/onfido/onfido-python/actions/runs/11404147149/job/31732689053).