### PR TITLE
[CAT-1528] Fix barcode field in document properties object

### DIFF
--- a/schemas/reports/document_properties.yaml
+++ b/schemas/reports/document_properties.yaml
@@ -122,49 +122,47 @@ properties:
       country_code:
         type: string
   barcode:
-    type: array
-    items:
-      type: object
-      properties:
-        first_name:
-          type: string
-        middle_name:
-          type: string
-        last_name:
-          type: string
-        document_type:
-          type: string
-        date_of_expiry:
-          type: string
-          format: date
-        date_of_birth:
-          type: string
-          format: date
-        issuing_date:
-          type: string
-          format: date
-        address_line_1:
-          type: string
-        address_line_2:
-          type: string
-        address_line_3:
-          type: string
-        address_line_4:
-          type: string
-        address_line_5:
-          type: string
-        issuing_state:
-          type: string
-        class:
-          type: string
-        gender:
-          type: string
-        issuing_country:
-          type: string
-        document_number:
-          type: string
-        real_id_classification:
-          type: string
+    type: object
+    properties:
+      first_name:
+        type: string
+      middle_name:
+        type: string
+      last_name:
+        type: string
+      document_type:
+        type: string
+      date_of_expiry:
+        type: string
+        format: date
+      date_of_birth:
+        type: string
+        format: date
+      issuing_date:
+        type: string
+        format: date
+      address_line_1:
+        type: string
+      address_line_2:
+        type: string
+      address_line_3:
+        type: string
+      address_line_4:
+        type: string
+      address_line_5:
+        type: string
+      issuing_state:
+        type: string
+      class:
+        type: string
+      gender:
+        type: string
+      issuing_country:
+        type: string
+      document_number:
+        type: string
+      real_id_classification:
+        type: string
   nfc:
     type: object
     properties:


### PR DESCRIPTION
Change barcode field in report properties from list to object for reports below:
- document
- document_video
- document_video_with_address_information
- document_with_address_information
- document_with_driver_verification
- document_with_driving_licence_information
- us_driving_licence

Change will be delivered in a minor release since this barcode property was completely broken and therefore it should not impact anyone