### PR TITLE
[CAT-1593] Drop invalid enum value from webhook event type

### DIFF
--- a/schemas/webhooks/definitions.yaml
+++ b/schemas/webhooks/definitions.yaml
@@ -84,7 +84,6 @@ webhook_event_type:
     - report.awaiting_approval
     - report.completed
     - workflow_timeline_file.created
-    - workflow_signed_evidence_file.created
     - workflow_run_evidence_folder.created
 
 webhook_url:


### PR DESCRIPTION
Drop `workflow_signed_evidence_file.created` form webhook event type

NB: it requires a major release