### PR TITLE
[CAT-1590] Allow any type for the workflow task output

### DIFF
--- a/schemas/tasks/task.yaml
+++ b/schemas/tasks/task.yaml
@@ -16,9 +16,8 @@ properties:
     type: object
     description: Input object with the fields used by the Task to execute.
   output:
-    type: object
     nullable: true
-    description: Output object with the fields produced by the Task execution.
+    description: Value field (it can be an Object, List, etc.) with the fields produced by the Task execution.
   created_at:
     type: string
     format: date-time

--- a/schemas/webhooks/webhook_event.yaml
+++ b/schemas/webhooks/webhook_event.yaml
@@ -92,9 +92,8 @@ properties:
             type: object
             description: Input object with the fields used by the Task execution.
           output:
-            type: object
             nullable: true
-            description: Output object with the fields produced by the Task execution.
+            description: Value field (it can be an Object, List, etc.) with the fields produced by the Task execution.
           reasons:
             type: array
             items:

--- a/shell/sync-lib.sh
+++ b/shell/sync-lib.sh
@@ -57,6 +57,9 @@ case $client_lib_name in
 
   python)
     sed $SED_OPTS "s/ *$//" pyproject.toml setup.py
+    sed $SED_OPTS 's/output: Optional\[Dict\[str, Any\]\]/output: Any/g' \
+      onfido/models/webhook_event_payload_resource.py \
+      onfido/models/task.py
     pipx run poetry==1.8 lock
   ;;
 


### PR DESCRIPTION
By removing the property type, it becomes a `Any` type, meaning that it can be anything as expected.

NB: small sed patch as in python otherwise it would remain `Optional[List[StrictStr]]` instead of `Any`: this change should be pushed to openapi generator (https://github.com/OpenAPITools/openapi-generator/blob/899ddecdbdb9b157ebbf3efbcfdf95ad7cf9740e/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java#L949).