### PR TITLE
Revert "add applicant_id in GET /workflow_runs"

### DIFF
--- a/paths/workflow_runs.yaml
+++ b/paths/workflow_runs.yaml
@@ -57,13 +57,6 @@ workflow_runs:
             - desc
             - asc
           default: desc
-      - in: query
-        name: applicant_id
-        required: false
-        schema:
-          type: string
-          format: uuid
-        description: the applicant's id.
     responses:
       "200":
         description: An array of Workflow Run objects matching the query parameters.


### PR DESCRIPTION
Reverts onfido/onfido-openapi-spec#136

Reverting this change for now as it's causing a breaking change on in java client library, i.e.:
```
-    public List<WorkflowRun> listWorkflowRuns(Integer page, String status, OffsetDateTime createdAtGt, OffsetDateTime createdAtLt, String sort) throws ApiException {
-        ApiResponse<List<WorkflowRun>> localVarResp = listWorkflowRunsWithHttpInfo(page, status, createdAtGt, createdAtLt, sort);
+    public List<WorkflowRun> listWorkflowRuns(Integer page, String status, OffsetDateTime createdAtGt, OffsetDateTime createdAtLt, String 
sort, UUID applicantId) throws ApiException {
+        ApiResponse<List<WorkflowRun>> localVarResp = listWorkflowRunsWithHttpInfo(page, status, createdAtGt, createdAtLt, sort, applicantId);
```
A new PR will be submitted just after.