### PR TITLE
[STUDIO-4305] Add download evidence folder path

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -45,6 +45,8 @@ paths:
     $ref: paths/workflow_runs.yaml#/retrieve
   /workflow_runs/{workflow_run_id}/signed_evidence_file:
     $ref: paths/workflow_runs.yaml#/signed_evidence_file
+  /workflow_runs/{workflow_run_id}/evidence_folder:
+    $ref: paths/workflow_runs.yaml#/evidence_folder
   # Documents
   /documents:
     $ref: paths/documents.yaml#/documents

--- a/paths/workflow_runs.yaml
+++ b/paths/workflow_runs.yaml
@@ -126,3 +126,36 @@ signed_evidence_file:
               format: binary
       default:
         $ref: ../responses/default_error.yaml
+
+evidence_folder:
+  get:
+    summary: Retrieve Workflow Run Evidence Folder
+    operationId: download_evidence_folder
+    description: >
+      Retrieves the evidence folder for the designated Workflow Run
+    parameters:
+      - name: workflow_run_id
+        in: path
+        description: Workflow Run ID
+        required: true
+        schema:
+          type: string
+          format: uuid
+    responses:
+      "302":
+        description: Found
+        headers:
+          Location:
+            description: Link to the evidence folder.
+            schema:
+              type: string
+              format: uri
+      "200":
+        description: The evidence folder binary data.
+        content:
+          application/zip:
+            schema:
+              type: string
+              format: binary
+      default:
+        $ref: ../responses/default_error.yaml


### PR DESCRIPTION
This PR adds the ability to download the Workflow Run Evidence Folder.

For more information about the product: https://documentation.onfido.com/api/latest/#retrieve-workflow-run-evidence-folder