### PR TITLE
Use Poetry only for dependecy management

### DIFF
--- a/generators/python/urllib3/templates/pyproject.mustache
+++ b/generators/python/urllib3/templates/pyproject.mustache
@@ -8,6 +8,7 @@ readme = "README.md"
 repository = "https://{{{gitHost}}}/{{{gitUserId}}}/{{{gitRepoId}}}"
 keywords = ["OpenAPI", "OpenAPI-Generator", "onfido", "identity"] {{! cutomized keywords }}
 include = ["{{packageName}}/py.typed"]
+package-mode = false
 
 {{! Added section }}
 [tool.poetry.urls]


### PR DESCRIPTION
With the upgrade to 2.0 it's now possible to use Poetry for dependency management and packaging so we need to set the package mode:

https://python-poetry.org/docs/basic-usage/#operating-modes

This change was used in the last release but committed directly in the release branch: https://github.com/onfido/onfido-python/pull/78