### PR TITLE
[CAT-1634] Add proxy configuration support to Java client library

### DIFF
--- a/generators/java/okhttp-gson/templates/README.mustache
+++ b/generators/java/okhttp-gson/templates/README.mustache
@@ -103,7 +103,8 @@ DefaultApi onfido = new DefaultApi(Configuration.getDefaultApiClient()
                       .setApiToken(System.getenv("ONFIDO_API_TOKEN"))
                       .setRegion(Region.EU)     // Supports `EU`, `US` and `CA`
                       .setConnectTimeout(60_000)
-                      .setReadTimeout(60_000));
+                      .setReadTimeout(60_000)
+                      .setProxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress(host, port))));   // Optionally define a connection proxy with the specified host and port
 ```
 
 NB: by default, timeout values are set to 30 seconds.

--- a/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
+++ b/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
@@ -56,6 +56,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.net.Proxy;{{! Added import }}
 
 import {{invokerPackage}}.auth.Authentication;
 import {{invokerPackage}}.auth.HttpBasicAuth;
@@ -568,12 +569,24 @@ public class ApiClient {
 
     {{! Added methods - BEGIN }}
 
+    /**
+     * Sets the Api Token.
+     *
+     * @param apiToken a String with the api token
+     * @return Api client
+     */
     public ApiClient setApiToken(String apiToken) {
         this.setApiKey("Token token=" + apiToken);
 
         return this;
     }
 
+    /**
+     * Sets the region.
+     *
+     * @param region a Region enum value
+     * @return Api client
+     */
     public ApiClient setRegion(Region region) {
         Map<String, String> serverVariables = getServerVariables();
 
@@ -586,6 +599,27 @@ public class ApiClient {
 
         return this;
     }
+
+    /**
+     * Return the HTTP proxy used by connections.
+     *
+     * @return Proxy
+     */
+    public Proxy getProxy() {
+        return httpClient.proxy();
+    }
+
+    /**
+     * Sets the HTTP proxy that will be used by connections.
+     *
+     * @param proxy a Proxy object
+     * @return Api client
+     */
+    public ApiClient setProxy(Proxy proxy) {
+        httpClient = httpClient.newBuilder().proxy(proxy).build();
+        return this;
+    }
+
     {{! Added methods - END }}
 
     /**

--- a/generators/python/urllib3/templates/pyproject.mustache
+++ b/generators/python/urllib3/templates/pyproject.mustache
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://{{{gitHost}}}/{{{gitUserId}}}/{{{gitRepoId}}}"
 keywords = ["OpenAPI", "OpenAPI-Generator", "onfido", "identity"] {{! cutomized keywords }}
 include = ["{{packageName}}/py.typed"]
-package-mode = false
+package-mode = false                                              {{! added option }}
 
 {{! Added section }}
 [tool.poetry.urls]


### PR DESCRIPTION
Allow providing a `java.net.Proxy` to the ApiClient object in Java client library.

Take the opportunity for adding a missing comment in one of the Python client library templates.