### PR TITLE
Specify webhook event resource output types

### DIFF
--- a/schemas/webhooks/webhook_event.yaml
+++ b/schemas/webhooks/webhook_event.yaml
@@ -92,6 +92,11 @@ properties:
             type: object
             description: Input object with the fields used by the Task execution.
           output:
+            anyOf:
+              - type: object
+              - type: array
+                items:
+                  type: object
             nullable: true
             description: Value field (it can be an Object, List, etc.) with the fields produced by the Task execution.
           reasons:


### PR DESCRIPTION
Output doesn't have a type, making the openapi generator default to a map of str: any, in reality it can also be a list of maps.

This currently causes failures in the python client when parsing webhook events.

<details>
<summary>example failing event (anonymised but copied from a real sandbox event):</summary>

```json
{
    "payload": {
        "resource_type": "workflow_task",
        "action": "workflow_task.completed",
        "object": {
            "id": "upload_document_photo_...",
            "task_spec_id": "upload_document_photo_...",
            "task_def_id": "upload_document_photo",
            "workflow_run_id": "00000000-0000-0000-0000-000000000000",
            "status": "completed",
            "completed_at_iso8601": "2025-01-23T22:35:02Z",
            "href": "https://api.ca.onfido.com/v3.6/workflow_runs/00000000-0000-0000-0000-000000000000/tasks/upload_document_photo_..."
        },
        "resource": {
            "task_def_version": null,
            "id": "upload_document_photo_...",
            "created_at": "2025-01-23T22:32:55Z",
            "input": {},
            "task_def_id": "upload_document_photo",
            "workflow_run_id": "00000000-0000-0000-0000-000000000000",
            "updated_at": "2025-01-23T22:35:02Z",
            "output": [
                {
                    "type": "document_photo",
                    "id": "11111111-1111-1111-1111-111111111111",
                    "checksum_sha256": "..."
                },
                {
                    "type": "document_photo",
                    "id": "22222222-2222-2222-2222-222222222222",
                    "checksum_sha256": "..."
                }
            ]
        }
    }
}
```

</details>

the important bit from the example above is:

```json
            "output": [
                {
                    "type": "document_photo",
                    "id": "11111111-1111-1111-1111-111111111111",
                    "checksum_sha256": "..."
                },
                {
                    "type": "document_photo",
                    "id": "22222222-2222-2222-2222-222222222222",
                    "checksum_sha256": "..."
                }
            ]
```

where `output` is a list of maps, not a map itself

