### PR TITLE
Denote webhook event payload.object.href as a not required property

### DIFF
--- a/schemas/webhooks/webhook_event.yaml
+++ b/schemas/webhooks/webhook_event.yaml
@@ -23,7 +23,6 @@ properties:
         type: object
         required:
           - id
-          - href
         description: The object affected by this event.
         properties:
           id:


### PR DESCRIPTION
In `audit_log.created` events, `payload.object` does not have an `href` property.

---

Library: onfido-python
Version: 4.6.0

Received webhook body:

```json
{
    "payload": {
        "resource_type": "audit_log",
        "action": "audit_log.created",
        "object": {
            "id": "...",
            "activity": "view_workflow_run",
            "category": "workflow_results",
            "created_at_iso8601": "2025-01-24T19:07:33Z",
            "user": {
                "email": "ollie@karoo.ca",
                "full_name": "Oliver Lambson",
                "ip_address": "..."
            }
        }
    }
}
```

```py
from onfido.models import WebhookEvent

WebhookEvent.from_json(raw_event)
```

```
Traceback (most recent call last):
  File ...
  File "/karoo/.venv/lib/python3.13/site-packages/onfido/webhook_event_verifier.py", line 27, in read_payload
    return WebhookEvent.from_json(raw_event)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/karoo/.venv/lib/python3.13/site-packages/onfido/models/webhook_event.py", line 53, in from_json
    return cls.from_dict(json.loads(json_str))
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/karoo/.venv/lib/python3.13/site-packages/onfido/models/webhook_event.py", line 95, in from_dict
    "payload": WebhookEventPayload.from_dict(obj["payload"]) if obj.get("payload") is not None else None
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/karoo/.venv/lib/python3.13/site-packages/onfido/models/webhook_event_payload.py", line 106, in from_dict
    "object": WebhookEventPayloadObject.from_dict(obj["object"]) if obj.get("object") is not None else None,
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/karoo/.venv/lib/python3.13/site-packages/onfido/models/webhook_event_payload_object.py", line 96, in from_dict
    _obj = cls.model_validate({
        "id": obj.get("id"),
    ...<3 lines>...
        "href": obj.get("href")
    })
  File "/karoo/.venv/lib/python3.13/site-packages/pydantic/main.py", line 627, in model_validate
    return cls.__pydantic_validator__.validate_python(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        obj, strict=strict, from_attributes=from_attributes, context=context
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
pydantic_core._pydantic_core.ValidationError: 1 validation error for WebhookEventPayloadObject
href
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.10/v/string_type
```