### PR TITLE
Show additional information on JSON decoding issue in Java client library

### DIFF
--- a/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
+++ b/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
@@ -1201,7 +1201,17 @@ public class ApiClient {
             contentType = "application/json";
         }
         if (isJsonMime(contentType)) {
-            return JSON.deserialize(respBody, returnType);
+            try {
+                return JSON.deserialize(respBody, returnType);
+            } catch (JsonParseException e) {
+                throw new ApiException(
+                        e.getMessage(),
+                        e,
+                        response.code(),
+                        response.headers().toMultimap(),
+                        respBody
+                );
+            }
         } else if (returnType.equals(String.class)) {
             // Expecting string, return the raw response body.
             return (T) respBody;

--- a/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
+++ b/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
@@ -56,7 +56,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.net.Proxy;{{! Added import }}
+{{! Added imports - BEGIN }}
+import java.net.Proxy;
+import com.google.gson.JsonParseException;
+{{! Added imports - END }}
 
 import {{invokerPackage}}.auth.Authentication;
 import {{invokerPackage}}.auth.HttpBasicAuth;
@@ -1201,6 +1204,7 @@ public class ApiClient {
             contentType = "application/json";
         }
         if (isJsonMime(contentType)) {
+            {{! Wrapped into try-catch block add more details on the exception }}
             try {
                 return JSON.deserialize(respBody, returnType);
             } catch (JsonParseException e) {


### PR DESCRIPTION
passing meaningful information into an exception when deserialisation goes wrong.

The current message looked like this:

com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected STRING but was BEGIN_OBJECT at path $.records[0]

We need to get more info to figure out what's the actual issue.