### PR TITLE
[CAT-1694] Define document type as free text

### DIFF
--- a/schemas/documents/definitions.yaml
+++ b/schemas/documents/definitions.yaml
@@ -3,11 +3,6 @@ document_shared:
   properties:
     file_type:
       type: string
-      enum:
-        - jpg
-        - jpeg
-        - png
-        - pdf
       description: The file type of the uploaded file
     type:
       type: string


### PR DESCRIPTION
Dropping the enum keyword from document since this property is freeflow, depending on the uploaded file name.

NB: this change isn't backward compatible, therefore needs to be delivered in a major release.