### PR TITLE
Add missing import ApiClient in ruby client library

### DIFF
--- a/generators/ruby/faraday/templates/SHA256SUM
+++ b/generators/ruby/faraday/templates/SHA256SUM
@@ -1,5 +1,6 @@
 
 631eea1aeb59eff826cd4975334d66bdf7ad14d3feacdf35ed5b07f33548981e  ./Gemfile.mustache
 0394740e8dc344748f61724a7fb304c23daf1e66922efa995c195968a0919ef4  ./README.mustache
+4f1869f928347c575dc8faff649e33cab5ac80e8615c1e2b937fe45a09c026ed  ./api_client.mustache
 8d952d2c3d4d49e0811a470b7e5e8c7c8dc798cf2f32e69d4501fc26be91a29a  ./configuration.mustache
 e66f0139c35c8b1d88c19787b2379ee9e6857ced963624c9a945ee68f3b41b2f  ./gemspec.mustache

--- a/generators/ruby/faraday/templates/api_client.mustache
+++ b/generators/ruby/faraday/templates/api_client.mustache
@@ -1,0 +1,247 @@
+=begin
+{{> api_info}}
+=end
+
+require 'date'
+require 'json'
+require 'logger'
+require 'tempfile'
+require 'time'
+{{#isTyphoeus}}
+require 'typhoeus'
+{{/isTyphoeus}}
+{{#isFaraday}}
+require 'faraday'
+require 'faraday/multipart' if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2.0')
+require 'marcel'
+{{/isFaraday}}
+{{#isHttpx}}
+require 'httpx'
+require 'net/http/status'
+{{/isHttpx}}
+
+require 'pathname'  {{! Added import }}
+
+module {{moduleName}}
+  class ApiClient
+    # The Configuration object holding settings to be used in the API client.
+    attr_accessor :config
+
+    # Defines the headers to be used in HTTP requests of all API calls by default.
+    #
+    # @return [Hash]
+    attr_accessor :default_headers
+
+    # Initializes the ApiClient
+    # @option config [Configuration] Configuration for initializing the object, default to Configuration.default
+    def initialize(config = Configuration.default)
+      @config = config
+      @user_agent = "{{{httpUserAgent}}}{{^httpUserAgent}}OpenAPI-Generator/#{VERSION}/ruby{{/httpUserAgent}}"
+      @default_headers = {
+        'Content-Type' => 'application/json',
+        'User-Agent' => @user_agent
+      }
+    end
+
+    def self.default
+      @@default ||= ApiClient.new
+    end
+
+{{#isTyphoeus}}
+{{> api_client_typhoeus_partial}}
+{{/isTyphoeus}}
+{{#isFaraday}}
+{{> api_client_faraday_partial}}
+{{/isFaraday}}
+{{#isHttpx}}
+{{> api_client_httpx_partial}}
+{{/isHttpx}}
+    # Check if the given MIME is a JSON MIME.
+    # JSON MIME examples:
+    #   application/json
+    #   application/json; charset=UTF8
+    #   APPLICATION/JSON
+    #   */*
+    # @param [String] mime MIME
+    # @return [Boolean] True if the MIME is application/json
+    def json_mime?(mime)
+      (mime == '*/*') || !(mime =~ /^Application\/.*json(?!p)(;.*)?/i).nil?
+    end
+
+    # Deserialize the response to the given return type.
+    #
+    # @param [Response] response HTTP response
+    # @param [String] return_type some examples: "User", "Array<User>", "Hash<String, Integer>"
+    def deserialize(response, return_type)
+      body = response.body
+      return nil if body.nil? || body.empty?
+
+      # return response body directly for String return type
+      return body.to_s if return_type == 'String'
+
+      # ensuring a default content type
+      content_type = response.headers['Content-Type'] || 'application/json'
+
+      fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
+
+      begin
+        data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+      rescue JSON::ParserError => e
+        if %w(String Date Time).include?(return_type)
+          data = body
+        else
+          raise e
+        end
+      end
+
+      convert_to_type data, return_type
+    end
+
+    # Convert data to the given return type.
+    # @param [Object] data Data to be converted
+    # @param [String] return_type Return type
+    # @return [Mixed] Data in a particular type
+    def convert_to_type(data, return_type)
+      return nil if data.nil?
+      case return_type
+      when 'String'
+        data.to_s
+      when 'Integer'
+        data.to_i
+      when 'Float'
+        data.to_f
+      when 'Boolean'
+        data == true
+      when 'Time'
+        # parse date time (expecting ISO 8601 format)
+        Time.parse data
+      when 'Date'
+        # parse date time (expecting ISO 8601 format)
+        Date.parse data
+      when 'Object'
+        # generic object (usually a Hash), return directly
+        data
+      when /\AArray<(.+)>\z/
+        # e.g. Array<Pet>
+        sub_type = $1
+        data.map { |item| convert_to_type(item, sub_type) }
+      when /\AHash\<String, (.+)\>\z/
+        # e.g. Hash<String, Integer>
+        sub_type = $1
+        {}.tap do |hash|
+          data.each { |k, v| hash[k] = convert_to_type(v, sub_type) }
+        end
+      else
+        # models (e.g. Pet) or oneOf
+        klass = {{moduleName}}.const_get(return_type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(data) : klass.build_from_hash(data)
+      end
+    end
+
+    # Sanitize filename by removing path.
+    # e.g. ../../sun.gif becomes sun.gif
+    #
+    # @param [String] filename the filename to be sanitized
+    # @return [String] the sanitized filename
+    def sanitize_filename(filename)
+      filename.split(/[\/\\]/).last
+    end
+
+    def build_request_url(path, opts = {})
+      # Add leading and trailing slashes to path
+      path = "/#{path}".gsub(/\/+/, '/')
+      @config.base_url(opts[:operation]) + path
+    end
+
+    # Update header and query params based on authentication settings.
+    #
+    # @param [Hash] header_params Header parameters
+    # @param [Hash] query_params Query parameters
+    # @param [String] auth_names Authentication scheme name
+    def update_params_for_auth!(header_params, query_params, auth_names)
+      Array(auth_names).each do |auth_name|
+        auth_setting = @config.auth_settings[auth_name]
+        next unless auth_setting
+        case auth_setting[:in]
+        when 'header' then header_params[auth_setting[:key]] = auth_setting[:value]
+        when 'query'  then query_params[auth_setting[:key]] = auth_setting[:value]
+        else fail ArgumentError, 'Authentication token must be in `query` or `header`'
+        end
+      end
+    end
+
+    # Sets user agent in HTTP header
+    #
+    # @param [String] user_agent User agent (e.g. openapi-generator/ruby/1.0.0)
+    def user_agent=(user_agent)
+      @user_agent = user_agent
+      @default_headers['User-Agent'] = @user_agent
+    end
+
+    # Return Accept header based on an array of accepts provided.
+    # @param [Array] accepts array for Accept
+    # @return [String] the Accept header (e.g. application/json)
+    def select_header_accept(accepts)
+      return nil if accepts.nil? || accepts.empty?
+      # use JSON when present, otherwise use all of the provided
+      json_accept = accepts.find { |s| json_mime?(s) }
+      json_accept || accepts.join(',')
+    end
+
+    # Return Content-Type header based on an array of content types provided.
+    # @param [Array] content_types array for Content-Type
+    # @return [String] the Content-Type header  (e.g. application/json)
+    def select_header_content_type(content_types)
+      # return nil by default
+      return if content_types.nil? || content_types.empty?
+      # use JSON when present, otherwise use the first one
+      json_content_type = content_types.find { |s| json_mime?(s) }
+      json_content_type || content_types.first
+    end
+
+    # Convert object (array, hash, object, etc) to JSON string.
+    # @param [Object] model object to be converted into JSON string
+    # @return [String] JSON string representation of the object
+    def object_to_http_body(model)
+      return model if model.nil? || model.is_a?(String)
+      local_body = nil
+      if model.is_a?(Array)
+        local_body = model.map { |m| object_to_hash(m) }
+      else
+        local_body = object_to_hash(model)
+      end
+      local_body.to_json
+    end
+
+    # Convert object(non-array) to hash.
+    # @param [Object] obj object to be converted into JSON string
+    # @return [String] JSON string representation of the object
+    def object_to_hash(obj)
+      if obj.respond_to?(:to_hash)
+        obj.to_hash
+      else
+        obj
+      end
+    end
+
+    # Build parameter value according to the given collection format.
+    # @param [String] collection_format one of :csv, :ssv, :tsv, :pipes and :multi
+    def build_collection_param(param, collection_format)
+      case collection_format
+      when :csv
+        param.join(',')
+      when :ssv
+        param.join(' ')
+      when :tsv
+        param.join("\t")
+      when :pipes
+        param.join('|')
+      when :multi
+        # return the array directly as typhoeus will handle it as expected
+        param
+      else
+        fail "unknown collection format: #{collection_format.inspect}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Template has added to add line below: 
```ruby
require 'pathname'  {{! Added import }}
```
The original file from the generator is available [here](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache).

This fix should be pushed upstream, the bug is consequence of this fix:
https://github.com/OpenAPITools/openapi-generator/pull/18243

fixing this other:
https://github.com/OpenAPITools/openapi-generator/pull/17853