### PR TITLE
[DOCCAP-2513] Add download-nfc-face endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -54,6 +54,8 @@ paths:
     $ref: paths/documents.yaml#/document
   /documents/{document_id}/download:
     $ref: paths/documents.yaml#/download
+  /documents/{document_id}/nfc_face:
+    $ref: paths/documents.yaml#/nfc_face
   /documents/{document_id}/video/download:
     $ref: paths/documents.yaml#/video/download
   # Live Photos

--- a/paths/documents.yaml
+++ b/paths/documents.yaml
@@ -97,6 +97,30 @@ download:
       default:
         $ref: ../responses/default_error.yaml
 
+nfc_face:
+  get:
+    summary: Download NFC face
+    operationId: download_nfc_face
+    description: >
+      Downloads digital photos extracted from specific documents belonging to an applicant. If successful, the response will be the binary data representing the image.
+    parameters:
+      - name: document_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    responses:
+      "200":
+        description: The image binary data
+        content:
+          "*/*":
+            schema:
+              type: string
+              format: binary
+      default:
+        $ref: ../responses/default_error.yaml
+
 video:
   download:
     get:


### PR DESCRIPTION
Add the missing download-nfc-face endpoint (`/documents/{document_id}/nfc_face`) to the OpenAPI spec.

[Link to Onfido API reference](https://documentation.onfido.com/api/latest/#download-nfc-face)