### PR TITLE
[CAT-1719] Don't impose a type on deprecated records property in watchlist reports

### DIFF
--- a/schemas/reports/watchlist_aml_properties.yaml
+++ b/schemas/reports/watchlist_aml_properties.yaml
@@ -3,6 +3,5 @@ properties:
   records:
     description: Returns any matches including, but not limited to, name and date of birth of match, aliases and associates, and relevant events and sources.
     type: array
-    items:
-      type: string
+    items: {}
     deprecated: true

--- a/schemas/reports/watchlist_standard_properties.yaml
+++ b/schemas/reports/watchlist_standard_properties.yaml
@@ -3,6 +3,5 @@ properties:
   records:
     description: Returns any matches including, but not limited to, name and date of birth of match, aliases and associates, and relevant events and sources.
     type: array
-    items:
-      type: string
+    items: {}
     deprecated: true


### PR DESCRIPTION
The deprecated `records` property can be a list of objects, therefore type should not be imposed to string.