### PR TITLE
[CAT-1911] Fix document_with_driving_licence_information to be a list of objects

### DIFF
--- a/schemas/reports/document_properties.yaml
+++ b/schemas/reports/document_properties.yaml
@@ -198,18 +198,20 @@ properties:
       issuing_authority:
         type: string
   driving_licence_information:
-    type: object
-    properties:
-      category:
-        type: string
-      obtainment_date:
-        type: string
-        format: date
-      expiry_date:
-        type: string
-        format: date
-      codes:
-        type: string
+    type: array
+    items:
+      type: object
+      properties:
+        category:
+          type: string
+        obtainment_date:
+          type: string
+          format: date
+        expiry_date:
+          type: string
+          format: date
+        codes:
+          type: string
   document_classification:
     type: object
     properties:

--- a/schemas/reports/document_properties.yaml
+++ b/schemas/reports/document_properties.yaml
@@ -201,6 +201,7 @@ properties:
     type: array
     items:
       type: object
+      title: Document Properties Driving Licence Information Item
       properties:
         category:
           type: string


### PR DESCRIPTION
Fixing the definition of `document_with_driving_licence_information` property since it's not an object but a list of objects.

This is consistent with the documention: https://documentation.onfido.com/api/latest/#document-with-driving-licence-information