### PR TITLE
[CAT-1911] Remove driving licence information properties where not needed

### DIFF
--- a/schemas/reports/document_properties.yaml
+++ b/schemas/reports/document_properties.yaml
@@ -197,22 +197,6 @@ properties:
         format: date
       issuing_authority:
         type: string
-  driving_licence_information:
-    type: array
-    items:
-      type: object
-      title: Document Properties Driving Licence Information Item
-      properties:
-        category:
-          type: string
-        obtainment_date:
-          type: string
-          format: date
-        expiry_date:
-          type: string
-          format: date
-        codes:
-          type: string
   document_classification:
     type: object
     properties:

--- a/schemas/reports/document_properties_with_driving_licence_information.yaml
+++ b/schemas/reports/document_properties_with_driving_licence_information.yaml
@@ -1,0 +1,17 @@
+properties:
+  driving_licence_information:
+    type: array
+    items:
+      type: object
+      title: Document Properties Driving Licence Information Item
+      properties:
+        category:
+          type: string
+        obtainment_date:
+          type: string
+          format: date
+        expiry_date:
+          type: string
+          format: date
+        codes:
+          type: string

--- a/schemas/reports/document_with_driving_licence_information_report.yaml
+++ b/schemas/reports/document_with_driving_licence_information_report.yaml
@@ -6,4 +6,7 @@ allOf:
       breakdown:
         $ref: document_breakdown.yaml
       properties:
-        $ref: document_properties.yaml
+        title: Document Properties with Driving Licence Information
+        allOf:
+          - $ref: document_properties.yaml
+          - $ref: document_properties_with_driving_licence_information.yaml


### PR DESCRIPTION
As improvement after https://github.com/onfido/onfido-openapi-spec/pull/163, in this PR we're removing the driving license information from unneeded reports:

- `document_report`
- `document_video_report`
- `document_video_with_address_information_report`
- `document_with_address_information_report`
- `document_with_driver_verification_report`
- `us_driving_licence_report`

NB: This is going to be a non-backward compatible change, needing for a major release.