### PR TITLE
Fix storage of device_fingerprint_reuse field as float

### DIFF
--- a/schemas/reports/device_intelligence_breakdown.yaml
+++ b/schemas/reports/device_intelligence_breakdown.yaml
@@ -110,7 +110,7 @@ properties:
               - LOW_RISK
             description: Whether there is highly suspicious traffic related to the IP address. The risk depends on the overall ratio of clear checks on a given IP.
           device_fingerprint_reuse:
-            type: integer
+            type: number
             description: The number of times the device was used to create a report for a new applicant. A value greater than 1 indicates potential device reuse.
           single_device_used:
             type: boolean


### PR DESCRIPTION
The `device_fingerprint_reuse` field was supposed to be an integer. The number of times will always not have a decimal part.

But because of GRPC conversions in `result-store` we are storing this value as a float. It is not trivial to fix this. And on openapi, a float value can be represented as having a decimal part or not (it is optional), i.e. both `3` and `3.0` are valid.

So it is much easier to fix this issue on the field by saying the field is a float. Results will be valid when they are without decimal part, but will also be valid when the api returns `0.0`.