### PR TITLE
Fix storage of device_fingerprint_reuse properties as float

### DIFF
--- a/schemas/reports/device_intelligence_properties.yaml
+++ b/schemas/reports/device_intelligence_properties.yaml
@@ -46,7 +46,7 @@ properties:
           - LOW_RISK
         description: Whether there is highly suspicious traffic related to the IP address. The risk depends on the overall ratio of clear checks on a given IP.
       device_fingerprint_reuse:
-        type: integer
+        type: number
         description: The number of times the device was used to create a report for a new applicant. A value greater than 1 indicates potential device reuse.
       single_device_used:
         type: boolean


### PR DESCRIPTION
The `device_fingerprint_reuse` properties field was supposed to be an integer. The number of times will always not have a decimal part.

We already fix this issue for this field in the "breakdowns". This fixes it for properties.