### PR TITLE
Improve README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,6 @@ Described below is the procedure on how to deliver new client libraries:
 15. Copy and paste release notes `What's changed` section from onfido-openapi-spec's release notes just below the _Refresh onfido-..._ line, by:
     1. Removing lines that doesn't apply to current library and reference to current language if present
     2. Indenting of two spaces each line and replacing the intial asterix (`*`) with dash (`-`)
-    3. Removing `by...` (till the end of the line) for keeping `CHANGELOG.md` file clean
 16. Any additional change manually performed in the library (e.g. updated tests, etc) needs to be added after the _Refresh onfido-..._ block (and any eventual subitem), indented as usual (but using `-` as a list marker to make line appearing in the `CHANGELOG.md` file).
 17. Click on _Publish release_ button
 18. Check that workflows have been succesfully executed (by clicking on the _Action_ button)

--- a/generators/java/okhttp-gson/templates/README.mustache
+++ b/generators/java/okhttp-gson/templates/README.mustache
@@ -160,12 +160,20 @@ try {
 
 ### Recommendations
 
-### Don't share DefaultApi among different threads
+#### Don't share DefaultApi among different threads
 
 It's recommended to create an instance of `DefaultApi` per thread in a multithreaded environment to avoid potential issues.
 
 #### Do not use additional properties
 
 Except for retrieving Task object's outputs, avoid using `getAdditionalProperty()` or `getAdditionalProperties()` methods to access undefined properties to prevent breaking changes when these fields appear.
+
+#### Use the linter when contributing
+
+When contributing to the project, run the linter to ensure code quality:
+
+```bash
+google-java-format -i $(git ls-files src/test/\*.java)
+```
 
 {{ >README_footer }}


### PR DESCRIPTION
Small changes in the java README file and in the repo's one, to align the release procedure after https://github.com/onfido/onfido-actions/pull/6.