### PR TITLE
[CAT-2201] Solve security alert in onfido-java client library

### DIFF
--- a/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
+++ b/generators/java/okhttp-gson/templates/libraries/okhttp-gson/ApiClient.mustache
@@ -363,22 +363,25 @@ public class ApiClient {
         return this;
     }
 
-    /**
+    /** {{! Comment has been updated }}
      * True if isVerifyingSsl flag is on
      *
-     * @return True if isVerifySsl flag is on
+     * @return True if SSL verification is enabled (always true for security)
      */
     public boolean isVerifyingSsl() {
         return verifyingSsl;
     }
 
-    /**
+    /** {{! Comment has been updated }}
      * Configure whether to verify certificate and hostname when making https requests.
      * Default to true.
-     * NOTE: Do NOT set to false in production code, otherwise you would face multiple types of cryptographic attacks.
+     * NOTE: Setting this to false is no longer supported for security reasons.
+     * SSL verification cannot be disabled to prevent man-in-the-middle attacks.
+     * If you need to use custom certificates, use setSslCaCert() instead.
      *
-     * @param verifyingSsl True to verify TLS/SSL connection
+     * @param verifyingSsl Must be true. Setting to false will throw an IllegalStateException.
      * @return ApiClient
+     * @throws IllegalStateException if verifyingSsl is set to false
      */
     public ApiClient setVerifyingSsl(boolean verifyingSsl) {
         this.verifyingSsl = verifyingSsl;
@@ -1819,29 +1822,14 @@ public class ApiClient {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
             if (!verifyingSsl) {
-                trustManagers = new TrustManager[]{
-                        new X509TrustManager() {
-                            @Override
-                            public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
-                            }
-
-                            @Override
-                            public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
-                            }
-
-                            @Override
-                            public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-                                return new java.security.cert.X509Certificate[]{};
-                            }
-                        }
-                };
-                hostnameVerifier = new HostnameVerifier() {
-                    @Override
-                    public boolean verify(String hostname, SSLSession session) {
-                        return true;
-                    }
-                };
-            } else {
+                {{! Reject attempts to disable SSL verification for security - BEGIN }}
+                throw new IllegalStateException("SSL verification cannot be disabled for security reasons. " +
+                        "This prevents man-in-the-middle attacks. If you need to use custom certificates, " +
+                        "use setSslCaCert() instead.");
+                {{! Reject attempts to disable SSL verification for security - END }}
+            }
+            else
+            {
                 TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
 
                 if (sslCaCert == null) {


### PR DESCRIPTION
Solve by templating the security warningin onfido-java: https://github.com/onfido/onfido-java/security/code-scanning/5

This prevent using of self-signed certificates if emitter has not been declared by calling `setSslCaCert()`.