### PR TITLE
[CAT-2289] Update the Postman collection UUID

### DIFF
--- a/.github/workflows/update-specs-and-client-libraries.yaml
+++ b/.github/workflows/update-specs-and-client-libraries.yaml
@@ -147,7 +147,7 @@ jobs:
             -p -O folderStrategy=Tags,parametersResolution=Example
           ./shell/publish-postman-collection.py \
             generated/artifacts/postman/collection.json \
-            38453665-3be48048-00b8-43bf-8c91-82953801b7aa
+            29927436-2b7c291e-121b-425f-9dcf-4a19e129bb46
         env:
           POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
       - name: Commit and push single-file OpenAPI specifications

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.0
 info:
-  title: Onfido API v3.6
+  title: Onfido Public API v3.6
   version: v3.6
-  description: The Onfido API (v3.6)
+  description: The Onfido Public API (v3.6)
   contact:
     name: Onfido
     url: https://public.support.onfido.com


### PR DESCRIPTION
Update the Postman collection UUID since previous one can't be used anymore.

Take the opportunity to add the Public in the OpenAPI spec, to have that propagated to the Onfido collection.