### PR TITLE
Improve description of ip_reuse fields

### DIFF
--- a/schemas/reports/device_intelligence_properties.yaml
+++ b/schemas/reports/device_intelligence_properties.yaml
@@ -37,10 +37,10 @@ properties:
         description: Whether the device is providing false randomized device and network information.
       number_of_ip_reuse_reports:
         type: number
-        description: Number of times the IP address used by the applicant to submit media matched an IP address associated with another report.
+        description: Counts the number of distinct document reports submitted in the last 24 hours that are associated with the applicant’s IP address.
       number_of_suspected_ip_reuse_reports:
         type: number
-        description: Number of times the IP address used by the applicant to submit media matched an IP address associated with a suspected report.
+        description: Counts the number of distinct document reports from the last 24 hours associated with the applicant’s IP address that have a result of suspected and other document integrity or authenticity signals have been flagged.
       fake_network_request:
         type: boolean
         description: Whether device is using stolen security tokens to send the network information.


### PR DESCRIPTION
We were missing the important point that we only count last 24hours . We also didn't mention that it only looks at document reports.