### PR TITLE
[DEXTV2-11695] Update document_types list

### DIFF
--- a/schemas/document_types/document_types.yaml
+++ b/schemas/document_types/document_types.yaml
@@ -75,4 +75,6 @@ enum:
   - identity_document_with_address
   - exchange_house_statement
   - accommodation_tenancy_certificate
+  - diplomatic_id
+  - travel_document
 type: string


### PR DESCRIPTION
We're missing 2 documents type in the specs, types we're currently returning in live reports.